### PR TITLE
add remove decoy rule, config and associated wrappers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,3 +57,7 @@ params:
     VariantRecalibrator: ""
   picard:
     MarkDuplicates: "REMOVE_DUPLICATES=false"
+
+  remove_decoy:
+    bed: "~/cre/data/grch37d5.decoy.bed"
+    fai: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/GRCh37d5/GRCh37d5.fa.fai"

--- a/config.yaml
+++ b/config.yaml
@@ -59,5 +59,5 @@ params:
     MarkDuplicates: "REMOVE_DUPLICATES=false"
 
   remove_decoy:
-    bed: "~/cre/data/grch37d5.decoy.bed"
+    bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre/data/grch37d5.decoy.bed"
     fai: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/GRCh37d5/GRCh37d5.fa.fai"

--- a/rules/calling.smk
+++ b/rules/calling.smk
@@ -10,7 +10,7 @@ if "restrict-regions" in config["processing"]:
             "bedextract {wildcards.contig} {input} > {output}"
 
 
-def get_sample_bams(wildcards):
+def get_decoy_removed_sample_bams(wildcards):
     """Get all aligned reads of given sample."""
     return expand("decoy_rm/{sample}-{unit}.no_decoy_reads.bam",
                   sample=wildcards.sample,

--- a/rules/calling.smk
+++ b/rules/calling.smk
@@ -10,6 +10,12 @@ if "restrict-regions" in config["processing"]:
             "bedextract {wildcards.contig} {input} > {output}"
 
 
+def get_sample_bams(wildcards):
+    """Get all aligned reads of given sample."""
+    return expand("decoy_rm/{sample}-{unit}.no_decoy_reads.bam",
+                  sample=wildcards.sample,
+                  unit=units.loc[wildcards.sample].unit)
+
 rule call_variants:
     input:
         bam=get_sample_bams,

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -61,7 +61,7 @@ rule remove_decoy:
     resources: mem_mb=10000
     shell:
         "samtools view {input.bam} -b -h -t {threads} -o {output.out_rm} -U {output.out_f} -L  {input.decoy}"
-        "samtools view -t {threads} {output.out_f}| grep -v hs37d5 | grep -v NC_007605 | samtools view - -hb > {output.out_f}"
+        "samtools view -h -t {threads} {output.out_f}| grep -v hs37d5 | grep -v NC_007605 | samtools view - -hb > {output.out_f}"
 
 rule samtools_index:
     input:

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -59,11 +59,9 @@ rule remove_decoy:
         "logs/remove_decoys/{sample}-{unit}.log"
     threads: 8
     resources: mem_mb=10000
-    wrapper:
-        get_wrapper_path("samtools", "remove_decoys") # or whatever 
-    # shell:
-    #     "samtools view {input.bam} -b -h -t {threads} -o {output.out_rm} -U {output.out_f} -L  {input.decoy}"
-    #     "samtools view -t {threads} {output.out_f}| grep -v hs37d5 | grep -v NC_007605 | samtools view - -hb > {output.out_f}"
+    shell:
+        "samtools view {input.bam} -b -h -t {threads} -o {output.out_rm} -U {output.out_f} -L  {input.decoy}"
+        "samtools view -t {threads} {output.out_f}| grep -v hs37d5 | grep -v NC_007605 | samtools view - -hb > {output.out_f}"
 
 rule samtools_index:
     input:

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -48,6 +48,22 @@ rule recalibrate_base_qualities:
     wrapper:
         get_wrapper_path("gatk", "baserecalibrator")
 
+rule remove_decoy:
+    input:
+        bam = "recal/{sample}-{unit}.bam",
+        decoy = config["remove_decoy"]["bed"] 
+    output: 
+        out_rm = "decoy_rm/{sample}-{unit}.removed_reads.bam",
+        out_f = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam"
+    log:
+        "logs/remove_decoys/{sample}-{unit}.log"
+    threads: 8
+    resources: mem_mb=10000
+    wrapper:
+        get_wrapper_path("samtools", "remove_decoys") # or whatever 
+    # shell:
+    #     "samtools view {input.bam} -b -h -t {threads} -o {output.out_rm} -U {output.out_f} -L  {input.decoy}"
+    #     "samtools view -t {threads} {output.out_f}| grep -v hs37d5 | grep -v NC_007605 | samtools view - -hb > {output.out_f}"
 
 rule samtools_index:
     input:

--- a/wrappers/samtools/remove_decoys/environment.yaml
+++ b/wrappers/samtools/remove_decoys/environment.yaml
@@ -1,0 +1,6 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - samtools ==1.9

--- a/wrappers/samtools/remove_decoys/meta.yaml
+++ b/wrappers/samtools/remove_decoys/meta.yaml
@@ -1,0 +1,4 @@
+name: "decoy removal"
+description: "Removes decoy reads in grch37 using samtools"
+authors:
+  - Delvin So

--- a/wrappers/samtools/remove_decoys/wrapper.py
+++ b/wrappers/samtools/remove_decoys/wrapper.py
@@ -1,0 +1,19 @@
+__author__ = "Delvin So"
+__copyright__ = "Copyright 2020, Delvin So"
+__license__ = "MIT"
+
+from os import path
+from snakemake.shell import shell
+
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+bam = snakemake.input[0]
+decoy = snakemake.input[1]
+
+rm_reads = snakemake.output[0]
+out_f = snakemake.output[1]
+
+
+shell = (
+    "samtools view {bam} -b -h -t {snakemake.threads} -o {rm_reads} -U {out_f} -L  {decoy}"
+    "samtools view -t {snakemake.threads} {out_f}| grep -v hs37d5 | grep -v NC_007605 | samtools view - -hb > {out_f}"
+)

--- a/wrappers/samtools/remove_decoys/wrapper.py
+++ b/wrappers/samtools/remove_decoys/wrapper.py
@@ -15,5 +15,5 @@ out_f = snakemake.output[1]
 
 shell = (
     "samtools view {bam} -b -h -t {snakemake.threads} -o {rm_reads} -U {out_f} -L  {decoy}"
-    "samtools view -t {snakemake.threads} {out_f}| grep -v hs37d5 | grep -v NC_007605 | samtools view - -hb > {out_f}"
+    "samtools view -h -t{snakemake.threads} {out_f}| grep -v hs37d5 | grep -v NC_007605 | samtools view - -hb > {out_f}"
 )


### PR DESCRIPTION

* Using wrapper instead of shell script to maintain samtools versioning (per environment.yaml)
* Comparison of bans from variantbam vs samtools removal of decoy reads. Identical file size:
```
-rw-r--r-- 1 delvinso 8867732622 May 27 14:46 NA12878-1.no_decoy_reads.bam
-rw-r--r-- 1 delvinso 8867732622 May 28 16:54 NA12878-1.no_decoy_reads_st.bam
```
* Dry run passes
```
rule remove_decoy:
    input: recal/NA12878-1.bam, /home/delvinso/cre/data/grch37d5.decoy.bed
    output: decoy_rm/NA12878-1.removed_reads.bam, decoy_rm/NA12878-1.no_decoy_reads.bam
    log: logs/remove_decoys/NA12878-1.log
    jobid: 270
    wildcards: sample=NA12878, unit=1
    threads: 8
    resources: mem_mb=10000
Job counts:
	count	jobs
	1	all
	86	call_variants
	86	combine_calls
	86	genotype_variants
	2	hard_filter_calls
	1	map_reads
	1	merge_calls
	1	merge_variants
	1	recalibrate_base_qualities
	1	remove_decoy
	2	select_calls
	1	snvreport
	1	vcf2db
	1	vcfanno
	1	vep
	1	vt
	273
```