### PR TITLE
Panel, Panel+Flank SNV reports, cleaned up config.yaml, updates to file paths, README updates,

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # crg2
-Research pipeline for exploring clinically relevant genomic variants
+Clinical research pipeline for exploring variants in whole genome sequencing data
 
 <div align="center">
     <img src="/crg2logolarge.png" width="800px"</img> 
@@ -27,11 +27,11 @@ snakemake --use-conda -s Snakefile --conda-prefix ~/crg2-conda --create-envs-onl
 ```
 Make sure to replace ```~/crg2-conda``` with the path made in step 4. This will take a while.
 
-6. Install plugins for VEP (TBA)
+6. Install these plugins for VEP: ```LoF, MaxEntScan, SpliceRegion```. Refer to this page for installation instructions: https://useast.ensembl.org/info/docs/tools/vep/script/vep_plugins.html. The INSTALL.pl script has been renamed to vep_install in the VEP's Conda build. It is located in the conda environment directory, under ```share/ensembl-vep-99.2-0/vep_install```.
 
 7. Git clone cre: ```git clone https://github.com/ccmbioinfo/cre``` to a safe place
 
-8. Replace the cre path in crg2/config.yaml with the one from step 7
+8. Replace the VEP path's to the VEP directory installed from step 6. Replace the cre path in crg2/config.yaml with the one from step 7.
 
 ## Running the pipeline
 1. Make a folder in a directory with sufficient space. Copy over the template files samples.tsv, units.tsv, config.yaml.
@@ -41,7 +41,7 @@ mkdir NA12878
 cp crg2/samples.tsv crg2/units.tsv crg2/config.yaml NA12878
 ```
 
-2. Reconfigure the 3 files to reflect project names, sample names and input fastq files.
+2. Reconfigure the 3 files to reflect project names, sample names, input fastq files, a panel bed file (if any) and a ped file (if any). Inclusion of a panel bed file will generate 2 SNV reports with all variants falling within these regions. Inclusion of a ped file currently does nothing except create a gemini db with the pedigree data stored in it.
 
 samples.tsv
 ```
@@ -57,10 +57,14 @@ NA12878	1	ILLUMINA	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA1287
 
 config.yaml
 ```
-project: "NA12878"
-samples: samples.tsv
-units: units.tsv
-
+run:
+  project: "NA12878"
+  samples: samples.tsv
+  units: units.tsv
+  ped: "" # leave this line blank if there is no ped
+  panel: "/hpf/largeprojects/ccmbio/dennis.kao/NA12878/panel.bed" # remove this line entirely if there is no panel bed file
+  flank: "100000"
+  
 cre: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre
 
 ref:
@@ -140,6 +144,8 @@ rule call_variants:
 
 3. GATK4 base recalibration
 
+4. Remove reads mapped to decoy chromosomes
+
 ### SNV
 1. Call SNV's and generate gVCFs
 
@@ -156,10 +162,30 @@ rule call_variants:
 7. Generate a cre report using cre.sh
 
 ### SV
-TBD
+1. Call SV's using Manta, Smoove and Wham
 
-## Report columns
+2. Merge calls using MetaSV
+
+3. Annotate VCF using snpEff and SVScores
+
+4. Split multi-sample VCF into individual sample VCFs
+
+5. Generate an annotated report using crg
+
+## Reports
+
+Column descriptions and more info on how variants are filtered can be found here:
 
 SNV: https://docs.google.com/document/d/1zL4QoINtkUd15a0AK4WzxXoTWp2MRcuQ9l_P9-xSlS4
 
 SV: https://docs.google.com/document/d/1o870tr0rcshoae_VkG1ZOoWNSAmorCZlhHDpZuZogYE
+
+The pipeline generates 4 reports:
+
+1. wgs.snv - a report on coding SNVs across the entire genome
+
+2. wgs.panel.snv - a report on SNVs within the panel specified bed file
+
+3. wgs.panel.snv - a report on SNVs within the panel specified bed file with a 100kb flank on each side
+
+4. wgs.sv - a report on SVs across the entire genome

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,8 @@ run:
   project: "NA12878"
   samples: samples.tsv
   units: units.tsv
-  panel: "/hpf/largeprojects/ccmbio/dennis.kao/NA12878/panel.bed"
+  ped: "" # leave this line blank if there is no ped
+  panel: "/hpf/largeprojects/ccmbio/dennis.kao/NA12878/panel.bed" # remove this line entirely if there is no panel bed file
   flank: "100000"
 
 cre: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre
@@ -43,8 +44,6 @@ annotation:
     dir_cache: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/vep-cache"
     maxentscan: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/c63b7268/share/ensembl-vep-99.2-0/maxEntScan"
     human_ancestor_fasta: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/human_ancestor.fa.gz"
-  vcf2db:
-    ped: ""
 
 params:
   bwa:

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ run:
   samples: samples.tsv
   units: units.tsv
   ped: "" # leave this line blank if there is no ped
-  panel: "/hpf/largeprojects/ccmbio/dennis.kao/NA12878/panel.bed" # remove this line entirely if there is no panel bed file
+  panel: "" # leave this line blank if there is no panel
   flank: "100000"
 
 cre: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre

--- a/config.yaml
+++ b/config.yaml
@@ -3,13 +3,14 @@ run:
   samples: samples.tsv
   units: units.tsv
   panel: "/hpf/largeprojects/ccmbio/dennis.kao/NA12878/panel.bed"
+  flank: "100000"
 
 cre: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre
 
 ref:
   name: GRCh37.75
   genome: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/GRCh37d5/GRCh37d5.fa
-  known-variants: /hpf/largeprojects/ccmbio/naumenko/tools/bcbio/gemini_data/dbsnp.b147.20160601.tidy.vcf.gz
+  known-variants: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/dbsnp.b147.20160601.tidy.vcf.gz
 
 filtering:
   # Set to true in order to apply machine learning based recalibration of
@@ -36,7 +37,7 @@ annotation:
   vcfanno:
     conf: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/crg2/vcfanno/crg.vcfanno.conf"
     lua_script: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/crg2/vcfanno/crg.vcfanno.lua"
-    base_path: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation"
+    base_path: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/vcfanno"
   vep:
     dir: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/c63b7268/share/ensembl-vep-99.2-0"
     dir_cache: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/vep-cache"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,8 @@
-project: "NA12878"
-samples: samples.tsv
-units: units.tsv
+run:
+  project: "NA12878"
+  samples: samples.tsv
+  units: units.tsv
+  panel: "/hpf/largeprojects/ccmbio/dennis.kao/NA12878/panel.bed"
 
 cre: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre
 

--- a/envs/cre.yaml
+++ b/envs/cre.yaml
@@ -6,6 +6,7 @@ dependencies:
   - gemini =0.30.2
   - vt =2015.11.10
   - bcftools =1.9
+  - bedtools =2.29.2
   - gatk4 =4.1.6.0
   - tabix =0.2.6
   - r =3.6.0

--- a/rules/annotation.smk
+++ b/rules/annotation.smk
@@ -66,7 +66,7 @@ rule vcf2db:
     log:
         "logs/vcf2db/vcf2db.log"
     params:
-        ped=config["annotation"]["vcf2db"]["ped"],
+        ped=config["run"]["ped"],
     threads: 1
     resources:
         mem_mb = 20000

--- a/rules/annotation.smk
+++ b/rules/annotation.smk
@@ -33,7 +33,7 @@ rule vcfanno:
     input:
         "annotated/vep/all.vep.vcf",
     output:
-        "annotated/vcfanno/all.vcfanno.vcf",
+        "annotated/vcfanno/all.vep.vcfanno.vcf",
     log:
         "logs/vcfanno/vcfanno.log"
     threads: 10
@@ -46,11 +46,23 @@ rule vcfanno:
     wrapper:
         get_wrapper_path("vcfanno")
 
+rule pass:
+    input:
+       	"annotated/vcfanno/all.vep.vcfanno.vcf",
+    output:
+        "annotated/all.vep.vcfanno.pass.vcf"
+    threads: 1
+    resources:
+        mem_mb = 4000
+    params: "-f PASS"
+    wrapper:
+        get_wrapper_path("bcftools", "view")
+
 rule vcf2db:
     input:
-        "annotated/vcfanno/all.vcfanno.vcf",
+        "annotated/all.vep.vcfanno.pass.vcf",
     output:
-         db="annotated/gemini.db",   # annotated calls (vcf, bcf, or vcf.gz)
+         db="annotated/gemini.db",
     log:
         "logs/vcf2db/vcf2db.log"
     params:

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -19,6 +19,8 @@ validate(units, schema="../schemas/units.schema.yaml")
 
 project=config["run"]["project"]
 
+flank=config["run"]["flank"]
+
 ##### Wildcard constraints #####
 wildcard_constraints:
     vartype="snvs|indels",

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -10,14 +10,14 @@ report: "../report/workflow.rst"
 configfile: "config.yaml"
 validate(config, schema="../schemas/config.schema.yaml")
 
-samples = pd.read_table(config["samples"]).set_index("sample", drop=False)
+samples = pd.read_table(config["run"]["samples"]).set_index("sample", drop=False)
 validate(samples, schema="../schemas/samples.schema.yaml")
 
-units = pd.read_table(config["units"], dtype=str).set_index(["sample", "unit"], drop=False)
+units = pd.read_table(config["run"]["units"], dtype=str).set_index(["sample", "unit"], drop=False)
 units.index = units.index.set_levels([i.astype(str) for i in units.index.levels])  # enforce str in index
 validate(units, schema="../schemas/units.schema.yaml")
 
-project=config["project"]
+project=config["run"]["project"]
 
 ##### Wildcard constraints #####
 wildcard_constraints:

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -1,13 +1,13 @@
-rule snvreport:
+rule allsnvreport:
     input:
         db="annotated/gemini.db",
         vcf="annotated/all.vep.vcfanno.pass.vcf"
     output:
-        directory("report")
+        directory("report/all")
     conda:
         "../envs/cre.yaml"
     log:
-        "logs/report/cre.log"
+        "logs/report/all-cre.log"
     threads: 2
     resources:
          mem_mb=40000
@@ -15,11 +15,69 @@ rule snvreport:
          cre=config["cre"],
          ref=config["ref"]["genome"]
     shell:
-         """
-         mkdir -p report/{project}
-         ln -s ../../{input.db} report/{project}/{project}-ensemble.db
-         bgzip {input.vcf} -c -@ 2 > report/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
-         ln -s ./{project}-gatk-haplotype-annotated-decomposed.vcf.gz report/{project}/{project}-ensemble-annotated-decomposed.vcf.gz
-         cd report
+         '''
+         mkdir -p report/all/{project}
+         ln -s ../../{input.db} report/all/{project}/{project}-ensemble.db
+         bgzip {input.vcf} -c -@ 2 > report/all/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
+         ln -s ./{project}-gatk-haplotype-annotated-decomposed.vcf.gz report/all/{project}/{project}-ensemble-annotated-decomposed.vcf.gz
+         cd report/all
          {params.cre}/cre.sh {project} {params.ref}
-         """
+         '''
+
+if "panel" in config["run"] and config["run"]["panel"]: #present in config file and non-empty string
+    rule panelsnvreport:
+        input:
+            db="annotated/gemini.db",
+            vcf="annotated/all.vep.vcfanno.pass.vcf",
+            panel=config["run"]["panel"]
+        output:
+            directory("report/panel")
+        conda:
+            "../envs/cre.yaml"
+        log:
+            "logs/report/panel-cre.log"
+        threads: 2
+        resources:
+            mem_mb=40000
+        params:
+            cre=config["cre"],
+            ref=config["ref"]["genome"]
+        shell:
+             '''
+             mkdir -p report/panel/{project}
+             ln -s ../../{input.db} report/panel/{project}/{project}-ensemble.db
+             bedtools intersect --header -a {input.vcf} -b {input.panel} | bgzip -c -@ 2 > report/panel/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
+             ln -s ./{project}-gatk-haplotype-annotated-decomposed.vcf.gz report/panel/{project}/{project}-ensemble-annotated-decomposed.vcf.gz
+             cd report/panel
+             {params.cre}/cre.sh {project} {params.ref}
+             '''
+
+    rule panelflanksnvreport:
+        input:
+            db="annotated/gemini.db",
+            vcf="annotated/all.vep.vcfanno.pass.vcf",
+            panel=config["run"]["panel"],
+        output:
+            dir=directory("report/panel-flank"),
+            panelflank="panel-{params.flank}.bed"
+        conda:
+            "../envs/cre.yaml"
+        log:
+            "logs/report/panel-flank-cre.log"
+        threads: 2
+        resources:
+            mem_mb=40000
+        params:
+            cre=config["cre"],
+            ref=config["ref"]["genome"],
+            flank=config["run"]["flank"]
+        shell:
+             '''
+             mkdir -p {output.dir}/{project}
+             ln -s ../../{input.db} {output.dir}/{project}-ensemble.db
+             cd {output.dir}
+             cat {input.panel} | awk -F "\t" '{{print $1"\t"$2-{params.flank}"\t"$3+{params.flank}}}' | sed 's/-[0-9]*/0/g' | bedtools sort | bedtools merge > {output.panelflank}
+             bedtools intersect --header -a {input.vcf} -b {output.panelflank} | bgzip -c -@ 2 > {project}-gatk-haplotype-annotated-deco$
+             ln -s ./{project}-gatk-haplotype-annotated-decomposed.vcf.gz {project}-ensemble-annotated-decomposed.vcf.gz
+             {params.cre}/cre.sh {project} {params.ref}
+             '''

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -1,7 +1,7 @@
 rule snvreport:
     input:
         db="annotated/gemini.db",
-        vcf="annotated/vcfanno/all.vcfanno.vcf"
+        vcf="annotated/all.vep.vcfanno.pass.vcf"
     output:
         directory("report")
     conda:

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -8,7 +8,6 @@ rule allsnvreport:
         "../envs/cre.yaml"
     log:
         "logs/report/all-cre.log"
-    threads: 2
     resources:
          mem_mb=40000
     params:
@@ -17,8 +16,8 @@ rule allsnvreport:
     shell:
          '''
          mkdir -p report/all/{project}
-         ln -s ../../{input.db} report/all/{project}/{project}-ensemble.db
-         bgzip {input.vcf} -c -@ 2 > report/all/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
+         ln -s ../../../{input.db} report/all/{project}/{project}-ensemble.db
+         bgzip {input.vcf} -c > report/all/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
          ln -s ./{project}-gatk-haplotype-annotated-decomposed.vcf.gz report/all/{project}/{project}-ensemble-annotated-decomposed.vcf.gz
          cd report/all
          {params.cre}/cre.sh {project} {params.ref}
@@ -31,24 +30,23 @@ if "panel" in config["run"] and config["run"]["panel"]: #present in config file 
             vcf="annotated/all.vep.vcfanno.pass.vcf",
             panel=config["run"]["panel"]
         output:
-            directory("report/panel")
+            dir=directory("report/panel")
         conda:
             "../envs/cre.yaml"
         log:
             "logs/report/panel-cre.log"
-        threads: 2
         resources:
             mem_mb=40000
         params:
             cre=config["cre"],
-            ref=config["ref"]["genome"]
+            ref=config["ref"]["genome"],
         shell:
              '''
-             mkdir -p report/panel/{project}
-             ln -s ../../{input.db} report/panel/{project}/{project}-ensemble.db
-             bedtools intersect --header -a {input.vcf} -b {input.panel} | bgzip -c -@ 2 > report/panel/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
-             ln -s ./{project}-gatk-haplotype-annotated-decomposed.vcf.gz report/panel/{project}/{project}-ensemble-annotated-decomposed.vcf.gz
-             cd report/panel
+             mkdir -p {output.dir}/{project}
+             ln -s ../../../{input.db} {output.dir}/{project}/{project}-ensemble.db
+             bedtools intersect -header -a {input.vcf} -b {input.panel} | bgzip -c > {output.dir}/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
+             ln -s {output.dir}/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz {output.dir}/{project}/{project}-ensemble-annotated-decomposed.vcf.gz
+             cd {output.dir}
              {params.cre}/cre.sh {project} {params.ref}
              '''
 
@@ -58,26 +56,24 @@ if "panel" in config["run"] and config["run"]["panel"]: #present in config file 
             vcf="annotated/all.vep.vcfanno.pass.vcf",
             panel=config["run"]["panel"],
         output:
-            dir=directory("report/panel-flank"),
-            panelflank="panel-{params.flank}.bed"
+            dir=directory("report/panel-flank-{flank}"),
+            panelflank="panel-{flank}.bed"
         conda:
             "../envs/cre.yaml"
         log:
-            "logs/report/panel-flank-cre.log"
-        threads: 2
+            "logs/report/panel-flank-{flank}-cre.log"
         resources:
             mem_mb=40000
         params:
             cre=config["cre"],
             ref=config["ref"]["genome"],
-            flank=config["run"]["flank"]
         shell:
              '''
              mkdir -p {output.dir}/{project}
-             ln -s ../../{input.db} {output.dir}/{project}-ensemble.db
+             ln -s ../../../{input.db} {output.dir}/{project}/{project}-ensemble.db
+             cat {input.panel} | awk -F "\t" '{{print $1"\t"$2-{flank}"\t"$3+{flank}}}' | sed 's/-[0-9]*/0/g' | bedtools sort | bedtools merge > {output.panelflank}
+             bedtools intersect -header -a {input.vcf} -b {output.panelflank} | bgzip -c > {output.dir}/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
              cd {output.dir}
-             cat {input.panel} | awk -F "\t" '{{print $1"\t"$2-{params.flank}"\t"$3+{params.flank}}}' | sed 's/-[0-9]*/0/g' | bedtools sort | bedtools merge > {output.panelflank}
-             bedtools intersect --header -a {input.vcf} -b {output.panelflank} | bgzip -c -@ 2 > {project}-gatk-haplotype-annotated-deco$
-             ln -s ./{project}-gatk-haplotype-annotated-decomposed.vcf.gz {project}-ensemble-annotated-decomposed.vcf.gz
+             ln -s {project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz {project}/{project}-ensemble-annotated-decomposed.vcf.gz
              {params.cre}/cre.sh {project} {params.ref}
              '''

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -23,7 +23,7 @@ rule allsnvreport:
          {params.cre}/cre.sh {project} {params.ref}
          '''
 
-if "panel" in config["run"] and config["run"]["panel"]: #present in config file and non-empty string
+if config["run"]["panel"]: #non-empty string
     rule panelsnvreport:
         input:
             db="annotated/gemini.db",

--- a/schemas/config.schema.yaml
+++ b/schemas/config.schema.yaml
@@ -5,10 +5,19 @@ description: snakemake configuration file
 type: object
 
 properties:
-  samples:
-    type: string
-  units:
-    type: string
+  run:
+    type: object
+    project:
+      type: string
+    samples:
+      type: string
+    units:
+      type: string
+    panel:
+      type: string
+    required:
+      - samples
+      - units
 
   ref:
     type: object
@@ -83,8 +92,7 @@ properties:
       - picard
 
 required:
-  - samples
-  - units
+  - run
   - ref
   - filtering
   - processing


### PR DESCRIPTION
- Panel and panel+flank snv report generation is optional and automatically generated
- config.yaml is a bit cleaner. Project specific values are now placed under the dictionary called "run"
- Annotation files have been copied over to the Common directory. Updated file paths to point to these files
- Added a SNV PASS rule before the vcf -> gemini.db conversion