### PR TITLE
bamtofastq functionality for bam input (CRG2-7)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,6 @@ run:
   project: "NA12878"
   samples: samples.tsv
   units: units.tsv
-  bam: False # change to True if input is bam instead of fastq
   ped: "" # leave this line blank if there is no ped
   panel: "" # leave this line blank if there is no panel
   flank: "100000"

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ run:
   project: "NA12878"
   samples: samples.tsv
   units: units.tsv
+  bam: False # change to True if input is bam instead of fastq
   ped: "" # leave this line blank if there is no ped
   panel: "" # leave this line blank if there is no panel
   flank: "100000"

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -75,16 +75,21 @@ def is_nonalt(chrom):
 
 def get_fastq(wildcards):
     """Get fastq files of given sample-unit."""
-    fastqs = units.loc[(wildcards.sample, wildcards.unit), ["fq1", "fq2"]].dropna()
+    sample = wildcards.sample
+    unit = wildcards.unit
+    fastqs = units.loc[(sample, unit), ["fq1", "fq2"]].dropna()
     if len(fastqs) == 2:
         return [fastqs.fq1, fastqs.fq2]
-    return [fastqs.fq1]
+    elif len(fastqs) == 1:
+        return [fastqs.fq1]
+    else:
+        return ["fastq/{sample}-{unit}_1.fq".format(sample=sample, unit=unit), "fastq/{sample}-{unit}_2.fq".format(sample=sample, unit=unit)]
 
 
 def get_bam(wildcards):
     """Get previously aligned bam files of given sample-unit."""
     bam_file = units.loc[(wildcards.sample, wildcards.unit), ["bam"]].dropna()
-    return [bam_file.bam]
+    return bam_file.bam
 
 
 def is_single_end(sample, unit):

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -13,12 +13,12 @@ validate(config, schema="../schemas/config.schema.yaml")
 samples = pd.read_table(config["run"]["samples"]).set_index("sample", drop=False)
 validate(samples, schema="../schemas/samples.schema.yaml")
 
-units = pd.read_table(config["units"], dtype=str).set_index(["sample", "unit"], drop=False)
+units = pd.read_table(config["run"]["units"], dtype=str).set_index(["sample", "unit"], drop=False)
 units.index = units.index.set_levels([i.astype(str)
                                       for i in units.index.levels])  # enforce str in index
 validate(units, schema="../schemas/units.schema.yaml")
 
-project = config["project"]
+project = config["run"]["project"]
 flank = config["run"]["flank"]
 
 ##### Wildcard constraints #####
@@ -79,6 +79,12 @@ def get_fastq(wildcards):
     if len(fastqs) == 2:
         return [fastqs.fq1, fastqs.fq2]
     return [fastqs.fq1]
+
+
+def get_bam(wildcards):
+    """Get previously aligned bam files of given sample-unit."""
+    bam_file = units.loc[(wildcards.sample, wildcards.unit), ["bam"]].dropna()
+    return [bam_file.bam]
 
 
 def is_single_end(sample, unit):

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -1,6 +1,20 @@
+rule bamtofastq:
+    input:
+        bam_file = get_bam
+    output:
+        fastq1 = temp("fastq/{sample}-{unit}_1.fq"),
+        fastq2 = temp("fastq/{sample}-{unit}_2.fq")
+    log:
+        "logs/bamtofastq/{sample}-{unit}.log"
+    threads:
+        4
+    wrapper:
+        get_wrapper_path("bedtools", "bamtofastq")
+
 rule map_reads:
     input:
-        reads = get_fastq
+        reads = get_fastq if config["run"]["bam"] == False else [
+            "fastq/{sample}-{unit}_1.fq", "fastq/{sample}-{unit}_2.fq"]
     output:
         temp("mapped/{sample}-{unit}.sorted.bam")
     log:
@@ -52,7 +66,7 @@ rule remove_decoy:
     input:
         bam = "recal/{sample}-{unit}.bam",
         decoy = config["params"]["remove_decoy"]["bed"],
-    output: 
+    output:
         temp_out = temp("decoy_rm/{sample}-{unit}.no_decoy_reads.temp.bam"),
         out_f = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam"
     log:

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -1,6 +1,9 @@
 rule bamtofastq:
     input:
         bam_file = get_bam
+    params:
+        outdir = temp("fastq/"),
+        sort_check = True
     output:
         fastq1 = temp("fastq/{sample}-{unit}_1.fq"),
         fastq2 = temp("fastq/{sample}-{unit}_2.fq")
@@ -13,8 +16,7 @@ rule bamtofastq:
 
 rule map_reads:
     input:
-        reads = get_fastq if config["run"]["bam"] == False else [
-            "fastq/{sample}-{unit}_1.fq", "fastq/{sample}-{unit}_2.fq"]
+        reads = get_fastq
     output:
         temp("mapped/{sample}-{unit}.sorted.bam")
     log:

--- a/schemas/units.schema.yaml
+++ b/schemas/units.schema.yaml
@@ -17,8 +17,10 @@ properties:
   fq2:
     type: string
     description: path to second FASTQ file (leave empty in case of single-end)
+  bam:
+    type: string
+    description: path to bam file (fill this in if fastqs are not available)
 required:
   - sample
   - unit
   - platform
-  - fq1

--- a/units.tsv
+++ b/units.tsv
@@ -1,2 +1,2 @@
-sample	unit	platform	fq1	fq2
+sample	unit	platform	fq1	fq2	bam
 NA12878	1	ILLUMINA	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_1.fq	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_2.fq

--- a/wrappers/bedtools/bamtofastq/environment.yaml
+++ b/wrappers/bedtools/bamtofastq/environment.yaml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - bedtools =2.29.0

--- a/wrappers/bedtools/bamtofastq/environment.yaml
+++ b/wrappers/bedtools/bamtofastq/environment.yaml
@@ -2,3 +2,4 @@ channels:
   - bioconda
 dependencies:
   - bedtools =2.29.0
+  - pysam =0.10.0

--- a/wrappers/bedtools/bamtofastq/wrapper.py
+++ b/wrappers/bedtools/bamtofastq/wrapper.py
@@ -1,0 +1,16 @@
+from snakemake.shell import shell
+
+log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+
+outdir = snakemake.output.fastq1.split('/')[0]
+
+shell(
+
+    "(samtools sort -n  "
+    "-@ {snakemake.threads} "
+    "-T {outdir}/{snakemake.wildcards.sample} "
+    "{snakemake.input} "
+    "| bedtools bamtofastq -i /dev/stdin "
+    "-fq {snakemake.output.fastq1} "
+    "-fq2 {snakemake.output.fastq2}) {log}"
+)

--- a/wrappers/bedtools/bamtofastq/wrapper.py
+++ b/wrappers/bedtools/bamtofastq/wrapper.py
@@ -1,16 +1,36 @@
 from snakemake.shell import shell
+import pysam
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-outdir = snakemake.output.fastq1.split('/')[0]
+sort_cmd = ""
+
+bamtofastq_cmd = (
+    " bedtools bamtofastq -i {snakemake.input.bam_file} "
+    "-fq {snakemake.output.fastq1} "
+    "-fq2 {snakemake.output.fastq2}"
+)
+
+# if bam is not sorted by query name, it must be re-sorted
+if snakemake.params.sort_check:
+    bam = pysam.AlignmentFile(snakemake.input.bam_file, "rb")
+    header = bam.header
+    sort_order = header["HD"]["SO"]
+    bam.close()
+
+    if sort_order != "queryname":
+        sort_cmd = (
+            "samtools sort -n "
+            "-@ {snakemake.threads} "
+            "-T {snakemake.params.outdir}/{snakemake.wildcards.sample} "
+            "{snakemake.input} |"
+        )
+        bamtofastq_cmd = (
+            " bedtools bamtofastq -i /dev/stdin "
+            "-fq {snakemake.output.fastq1} "
+            "-fq2 {snakemake.output.fastq2}"
+        )
 
 shell(
-
-    "(samtools sort -n  "
-    "-@ {snakemake.threads} "
-    "-T {outdir}/{snakemake.wildcards.sample} "
-    "{snakemake.input} "
-    "| bedtools bamtofastq -i /dev/stdin "
-    "-fq {snakemake.output.fastq1} "
-    "-fq2 {snakemake.output.fastq2}) {log}"
+    "(" + sort_cmd + bamtofastq_cmd + ") {log}"
 )


### PR DESCRIPTION
This adds the ability to use a bam file as input to crg2. Fastqs will be extracted from the bam file using bedtools bamtofastq and then re-aligned to the reference specified in the config. I added a 'bam' field into the units.tsv field. I also added a bam field under "run" in the config file: the default is False, but if set to True, the pipeline will use the bam file specified in the units.tsv file as input. 
I tried to set the units.schema.yaml to require fq1 or bam but couldn't figure it out :/
See `/hpf/largeprojects/ccmbio/mcouse/testing/crg2/NA12878_test_from_bam/` for example units.tsv and config.yaml files.