### PR TITLE
SV report generation

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,3 +1,5 @@
+PIPELINE_VERSION="0.9.0"
+
 include: "rules/common.smk"
 
 ##### Target rules #####

--- a/Snakefile
+++ b/Snakefile
@@ -9,7 +9,8 @@ rule all:
         "report/all",
         "report/panel" if config["run"]["panel"] else [],
         expand("report/panel-flank-{flank}", flank=flank) if config["run"]["panel"] else [],
-#        "qc/multiqc.html",
+        "report/sv",
+        "qc/multiqc/multiqc.html",
 #        "plots/depths.svg",
 #        "plots/allele-freqs.svg"
 
@@ -22,3 +23,5 @@ include: "rules/stats.smk"
 include: "rules/qc.smk"
 include: "rules/annotation.smk"
 include: "rules/snvreport.smk"
+include: "rules/sv.smk"
+include: "rules/svreport.smk"

--- a/config.yaml
+++ b/config.yaml
@@ -81,7 +81,7 @@ params:
   picard:
     MarkDuplicates: "REMOVE_DUPLICATES=false"
   qualimap:
-    mem: "4G"
+    mem: "75G"
     nw: 400
     c: "-c"
     hm: 3

--- a/config.yaml
+++ b/config.yaml
@@ -2,21 +2,25 @@ run:
   project: "NA12878"
   samples: samples.tsv
   units: units.tsv
-  ped: "" # leave this line blank if there is no ped
-  panel: "" # leave this line blank if there is no panel
+  ped: "" # leave this string empty if there is no ped
+  panel: "" # leave this string empty if there is no panel
+  hpo: "" # leave this string empty is there are no hpo terms
   flank: "100000"
+
+tools:
+  svscore_script: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/SVScore/svscore.pl"
 
 cre: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre
 
 ref:
   name: GRCh37.75
+  no_decoy_name: GRCh37
   genome: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/GRCh37d5/GRCh37d5.fa
   known-variants: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/dbsnp.b147.20160601.tidy.vcf.gz
   no_decoy: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/GRCh37/GRCh37.fa
+  decoy_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre/data/grch37d5.decoy.bed"
 
 filtering:
-  # Set to true in order to apply machine learning based recalibration of
-  # quality scores instead of hard filtering.
   vqsr: false
   hard:
     # hard filtering as outlined in GATK docs
@@ -45,6 +49,22 @@ annotation:
     dir_cache: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/vep-cache"
     maxentscan: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/c63b7268/share/ensembl-vep-99.2-0/maxEntScan"
     human_ancestor_fasta: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/human_ancestor.fa.gz"
+  snpeff:
+    dataDir: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/snpeff"
+  svscore:
+    exon_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/SVScore/refGene.exons.bed.gz"
+    intron_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/SVScore/refGene.introns.bed.gz"
+    cadd: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/SVScore/whole_genome_SNVs.tsv.gz"
+  svreport:
+    hgmd: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/HGMD_2018/hgmd_pro.db"
+    protein_coding_genes: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/grch37.p13.ensembl.sorted.protein.coding.genes.bed"
+    exon_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/protein_coding_genes.exons.fixed.sorted.bed"
+    exac: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExAC/fordist_cleaned_nonpsych_z_pli_rec_null_data.txt"
+    omim: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/OMIM_2020-04-09/genemap2.txt"
+    gnomad: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/gnomad_v2_sv.sites.bed"
+    biomart: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/BioMaRt.GrCh37.75.ensembl.mim.hgnc.entrez.txt"
+    mssng_manta_counts: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/MSSNG_COUNTS/Canadian_MSSNG_parent_SVs.Manta.counts.txt"
+    mssng_lumpy_counts: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/MSSNG_COUNTS/Canadian_MSSNG_parent_SVs.LUMPY.counts.txt"
 
 params:
   bwa:
@@ -69,6 +89,7 @@ params:
   verifybamid2:
     svd_prefix: "1000g.phase3 100k b37"
     extra: ""
-  remove_decoy:
-    bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre/data/grch37d5.decoy.bed"
-  
+  snpeff:
+    java_opts: "-Xms750m -Xmx20g"
+  svscore:
+    operations: "max,sum,top5,top10,mean"

--- a/config.yaml
+++ b/config.yaml
@@ -9,8 +9,9 @@ run:
 
 tools:
   svscore_script: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/SVScore/svscore.pl"
-
-cre: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre
+  annotsv: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/AnnotSV_2.1"
+  cre: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre"
+  crg: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/crg"
 
 ref:
   name: GRCh37.75
@@ -58,7 +59,7 @@ annotation:
   svreport:
     hgmd: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/HGMD_2018/hgmd_pro.db"
     protein_coding_genes: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/grch37.p13.ensembl.sorted.protein.coding.genes.bed"
-    exon_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/protein_coding_genes.exons.fixed.sorted.bed"
+    exon_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/grch37.p13.ensembl.protein.coding.genes.exons.fixed.sorted.bed"
     exac: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExAC/fordist_cleaned_nonpsych_z_pli_rec_null_data.txt"
     omim: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/OMIM_2020-04-09/genemap2.txt"
     gnomad: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/gnomad_v2_sv.sites.bed"

--- a/config.yaml
+++ b/config.yaml
@@ -82,7 +82,7 @@ params:
   picard:
     MarkDuplicates: "REMOVE_DUPLICATES=false"
   qualimap:
-    mem: "75G"
+    mem: "70G"
     nw: 400
     c: "-c"
     hm: 3

--- a/dnaseq.pbs
+++ b/dnaseq.pbs
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#PBS -l walltime=24:00:00,nodes=1:ppn=4
+#PBS -l walltime=72:00:00,nodes=1:ppn=4
 #PBS -joe .
 #PBS -d .
 #PBS -l vmem=80g,mem=80g

--- a/dnaseq.pbs
+++ b/dnaseq.pbs
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#PBS -l walltime=48:00:00,nodes=1:ppn=4
+#PBS -l walltime=24:00:00,nodes=1:ppn=4
 #PBS -joe .
 #PBS -d .
 #PBS -l vmem=80g,mem=80g

--- a/envs/crg.yaml
+++ b/envs/crg.yaml
@@ -1,0 +1,9 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - sqlite >3.2
+  - python >3.5
+  - scikit-allel >1.2
+  - pybedtools >0.8.0
+  - numpy >1.1

--- a/envs/samtools.yaml
+++ b/envs/samtools.yaml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - samtools ==1.10

--- a/envs/svscore.yaml
+++ b/envs/svscore.yaml
@@ -1,0 +1,14 @@
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - vt =2015.11.10
+  - tabix =0.2.6
+  - vcfanno =0.3.2
+  - pbgzip =2016.08.04
+  - svtools =0.5.1
+  - perl >5.10.1
+  - perl-list-moreutils =0.428
+  - perl-math-round =0.07
+  - perl-findbin =1.51

--- a/rules/annotation.smk
+++ b/rules/annotation.smk
@@ -12,7 +12,7 @@ rule vt:
 
 rule vep:
     input:
-        "filtered/all.uniq.normalized.decomposed.vcf",
+        "filtered/all.uniq.normalized.decomposed.pass.vcf",
     output:
         temp("annotated/vep/all.vep.vcf"),
     log:
@@ -48,9 +48,9 @@ rule vcfanno:
 
 rule pass:
     input:
-       	"annotated/vcfanno/all.vep.vcfanno.vcf",
+       	"{prefix}.{ext}"
     output:
-        "annotated/all.vep.vcfanno.pass.vcf"
+        temp("{prefix}.pass.{ext,(vcf|vcf\.gz)}")
     threads: 1
     resources:
         mem_mb = 4000
@@ -60,7 +60,7 @@ rule pass:
 
 rule vcf2db:
     input:
-        "annotated/all.vep.vcfanno.pass.vcf",
+        "annotated/vcfanno/all.vep.vcfanno.vcf",
     output:
          db="annotated/gemini.db",
     log:

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,6 +1,7 @@
 import pandas as pd
 from snakemake.utils import validate
 from snakemake.utils import min_version
+from datetime import date
 
 min_version("5.7.1")
 
@@ -153,6 +154,9 @@ def get_recal_input(bai=False):
     else:
         return f
 
+def get_annotated_sv_vcf():
+    """Get the annotated MetaSV vcf of given sample."""
+    return ["sv/metasv/{}-{}/variants.snpeff.svscore.vcf".format(sample, units.loc[sample].unit[0]) for sample in samples.index]
 
 def get_wrapper_path(*dirs):
     return "file:%s" % os.path.join(workflow.basedir, "wrappers", *dirs)

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -67,7 +67,7 @@ rule recalibrate_base_qualities:
 rule remove_decoy:
     input:
         bam = "recal/{sample}-{unit}.bam",
-        decoy = config["params"]["remove_decoy"]["bed"],
+        decoy = config["ref"]["decoy_bed"],
     output:
         temp_out = temp("decoy_rm/{sample}-{unit}.no_decoy_reads.temp.bam"),
         out_f = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam"

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -70,11 +70,13 @@ rule remove_decoy:
         decoy = config["ref"]["decoy_bed"],
     output:
         temp_out = temp("decoy_rm/{sample}-{unit}.no_decoy_reads.temp.bam"),
-        out_f = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam"
+        out_f = temp("decoy_rm/{sample}-{unit}.no_decoy_reads.bam")
     log:
         "logs/remove_decoys/{sample}-{unit}.log"
     threads: 8
     resources: mem_mb = 10000
+    conda:
+        "../envs/samtools.yaml"
     shell:
         """
         samtools view {input.bam} -b -h -t {threads} -U {output.temp_out} -L {input.decoy}

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -92,7 +92,6 @@ rule multiqc:
                                                             "qc/qualimap/{u.sample}-{u.unit}/raw_data_qualimapReport/mapped_reads_gc-content_distribution.txt", 
                                                             "qc/fastq_screen/{u.sample}-{u.unit}_screen.txt"
                                                                     ]]
-       # "snpeff/all.csv"
     params:
     output:
         report("qc/multiqc/multiqc.html", caption="../report/multiqc.rst", category="Quality control") 

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -53,7 +53,7 @@ rule qualimap:
         c = config["params"]["qualimap"]["c"],
         mem_size = config["params"]["qualimap"]["mem"],
         extra = config["params"]["qualimap"]["extra"]
-    threads: 4
+    threads: 8
     log:
         "logs/qualimap/{sample}-{unit}.log"
     wrapper:
@@ -99,5 +99,3 @@ rule multiqc:
         "logs/multiqc/multiqc.log"
     wrapper:
         get_wrapper_path("multiqc")
-
-

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -20,7 +20,7 @@ rule allsnvreport:
          bgzip {input.vcf} -c > report/all/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
          ln -s ./{project}-gatk-haplotype-annotated-decomposed.vcf.gz report/all/{project}/{project}-ensemble-annotated-decomposed.vcf.gz
          cd report/all
-         {params.cre}/cre.sh {project} {params.ref}
+         {params.cre}/cre.sh {project}
          '''
 
 if config["run"]["panel"]: #non-empty string
@@ -47,7 +47,7 @@ if config["run"]["panel"]: #non-empty string
              bedtools intersect -header -a {input.vcf} -b {input.panel} | bgzip -c > {output.dir}/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
              ln -s {output.dir}/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz {output.dir}/{project}/{project}-ensemble-annotated-decomposed.vcf.gz
              cd {output.dir}
-             {params.cre}/cre.sh {project} {params.ref}
+             {params.cre}/cre.sh {project}
              '''
 
     rule panelflanksnvreport:
@@ -75,5 +75,5 @@ if config["run"]["panel"]: #non-empty string
              bedtools intersect -header -a {input.vcf} -b {output.panelflank} | bgzip -c > {output.dir}/{project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz
              cd {output.dir}
              ln -s {project}/{project}-gatk-haplotype-annotated-decomposed.vcf.gz {project}/{project}-ensemble-annotated-decomposed.vcf.gz
-             {params.cre}/cre.sh {project} {params.ref}
+             {params.cre}/cre.sh {project}
              '''

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -11,7 +11,7 @@ rule allsnvreport:
     resources:
          mem_mb=40000
     params:
-         cre=config["cre"],
+         cre=config["tools"]["cre"],
          ref=config["ref"]["genome"]
     shell:
          '''
@@ -38,7 +38,7 @@ if config["run"]["panel"]: #non-empty string
         resources:
             mem_mb=40000
         params:
-            cre=config["cre"],
+            cre=config["tools"]["cre"],
             ref=config["ref"]["genome"],
         shell:
              '''
@@ -65,7 +65,7 @@ if config["run"]["panel"]: #non-empty string
         resources:
             mem_mb=40000
         params:
-            cre=config["cre"],
+            cre=config["tools"]["cre"],
             ref=config["ref"]["genome"],
         shell:
              '''

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -1,7 +1,7 @@
 rule allsnvreport:
     input:
         db="annotated/gemini.db",
-        vcf="annotated/all.vep.vcfanno.pass.vcf"
+        vcf="annotated/vcfanno/all.vep.vcfanno.vcf"
     output:
         directory("report/all")
     conda:
@@ -27,7 +27,7 @@ if config["run"]["panel"]: #non-empty string
     rule panelsnvreport:
         input:
             db="annotated/gemini.db",
-            vcf="annotated/all.vep.vcfanno.pass.vcf",
+            vcf="annotated/vcfanno/all.vep.vcfanno.vcf",
             panel=config["run"]["panel"]
         output:
             dir=directory("report/panel")
@@ -53,7 +53,7 @@ if config["run"]["panel"]: #non-empty string
     rule panelflanksnvreport:
         input:
             db="annotated/gemini.db",
-            vcf="annotated/all.vep.vcfanno.pass.vcf",
+            vcf="annotated/vcfanno/all.vep.vcfanno.vcf",
             panel=config["run"]["panel"],
         output:
             dir=directory("report/panel-flank-{flank}"),

--- a/rules/sv.smk
+++ b/rules/sv.smk
@@ -85,7 +85,7 @@ rule metasv:
 
 rule snpeff:
     input:
-        "sv/metasv/{sample}-{unit}/variants.vcf.gz"
+        "sv/metasv/{sample}-{unit}/variants.pass.vcf.gz"
     output:
         temp("sv/metasv/{sample}-{unit}/variants.snpeff.vcf")
     log:

--- a/rules/sv.smk
+++ b/rules/sv.smk
@@ -110,6 +110,8 @@ rule svscore:
         exon_bed=config["annotation"]["svscore"]["exon_bed"],
 	intron_bed=config["annotation"]["svscore"]["intron_bed"],
 	cadd=config["annotation"]["svscore"]["cadd"],
+    conda:
+        "../envs/svscore.yaml"
     shell:
         """
         perl -w {params.svscore_script} \

--- a/rules/svreport.smk
+++ b/rules/svreport.smk
@@ -6,6 +6,8 @@ rule svreport:
     log:
         "logs/report/sv.log"
     params:
+        PIPELINE_VERSION=PIPELINE_VERSION,
+        project=config["run"]["project"],
         hgmd=config["annotation"]["svreport"]["hgmd"],
         hpo=config["run"]["hpo"],
         protein_coding_genes=config["annotation"]["svreport"]["protein_coding_genes"],
@@ -16,12 +18,7 @@ rule svreport:
         biomart=config["annotation"]["svreport"]["biomart"],
         mssng_manta_counts=config["annotation"]["svreport"]["mssng_manta_counts"],
         mssng_lumpy_counts=config["annotation"]["svreport"]["mssng_lumpy_counts"],
-    shell:
-        """
-        mkdir -p {output.dir}
-        cd {output.dir}
-        python3 ~/crg/crg.intersect_sv_vcfs.py -protein_coding_genes={params.protein_coding_genes} -exon_bed={params.exon_bed} \
-        -hgmd={params.hgmd} -hpo={params.hpo} -exac={params.exac} -omim={params.omim} -biomart={params.biomart} -gnomad={params.gnomad} \
-        -sv_counts {params.mssng_manta_counts} ${params.mssng_lumpy_counts} \
-        -o={{"%s.wgs.sv.v%s.%s.tsv" % (project, PIPELINE_VERSION, date.today().strftime("%Y-%m-%d"))}} -i {{",".join(["../%s" % vcf for vcf in input[0]])}}
-        """
+    conda:
+        "../envs/crg.yaml"
+    script:
+        os.path.join(config["tools"]["crg"], "crg.intersect_sv_vcfs.py")

--- a/rules/svreport.smk
+++ b/rules/svreport.smk
@@ -1,0 +1,27 @@
+rule svreport:
+    input:
+        get_annotated_sv_vcf()
+    output:
+        dir=directory("report/sv")
+    log:
+        "logs/report/sv.log"
+    params:
+        hgmd=config["annotation"]["svreport"]["hgmd"],
+        hpo=config["run"]["hpo"],
+        protein_coding_genes=config["annotation"]["svreport"]["protein_coding_genes"],
+        exon_bed=config["annotation"]["svreport"]["exon_bed"],
+        exac=config["annotation"]["svreport"]["exac"],
+        omim=config["annotation"]["svreport"]["omim"],
+        gnomad=config["annotation"]["svreport"]["gnomad"],
+        biomart=config["annotation"]["svreport"]["biomart"],
+        mssng_manta_counts=config["annotation"]["svreport"]["mssng_manta_counts"],
+        mssng_lumpy_counts=config["annotation"]["svreport"]["mssng_lumpy_counts"],
+    shell:
+        """
+        mkdir -p {output.dir}
+        cd {output.dir}
+        python3 ~/crg/crg.intersect_sv_vcfs.py -protein_coding_genes={params.protein_coding_genes} -exon_bed={params.exon_bed} \
+        -hgmd={params.hgmd} -hpo={params.hpo} -exac={params.exac} -omim={params.omim} -biomart={params.biomart} -gnomad={params.gnomad} \
+        -sv_counts {params.mssng_manta_counts} ${params.mssng_lumpy_counts} \
+        -o={{"%s.wgs.sv.v%s.%s.tsv" % (project, PIPELINE_VERSION, date.today().strftime("%Y-%m-%d"))}} -i {{",".join(["../%s" % vcf for vcf in input[0]])}}
+        """

--- a/wrappers/bcftools/view/wrapper.py
+++ b/wrappers/bcftools/view/wrapper.py
@@ -6,7 +6,19 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 
+outfile = snakemake.output[0]
+
+compress_flags = ""
+
+if outfile.endswith("vcf.gz"):
+    compress_flags = "-Oz"
+elif outfile.endswith("vcf"):
+    compress_flags = "-Ov"
+elif outfile.endswith("bcf"):
+    compress_flags = "-Ou"
+elif outfile.endswith("bcf.gz"):
+    compress_flags = "-Ob"
 
 shell(
-    "bcftools view {snakemake.params} {snakemake.input[0]} " "-o {snakemake.output[0]}"
+    "bcftools view {snakemake.params} {snakemake.input[0]} {compress_flags} " "-o {outfile}"
 )

--- a/wrappers/snpeff/wrapper.py
+++ b/wrappers/snpeff/wrapper.py
@@ -3,8 +3,7 @@ from snakemake.shell import shell
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 shell(
-    "(snpEff {snakemake.params.memory_initial} "
-    "{snakemake.params.memory_max} "
+    "(snpEff {snakemake.params.java_opts} "
     "-i VCF "
     "-o VCF "
     "-dataDir {snakemake.params.data_dir} "


### PR DESCRIPTION
My last commit!

- Bumped up Qualimap ram. 4GB is too low. Online sources suggest that we use the whole size of the bam, as to prevent garbage collection as much as possible
- Implemented annotations for SVScore. Because this tool cannot be found on Anaconda.org, it must be run under the shell directive. I added an environment file as well.
- Implemented SV report generation. Has it's own isolated environment.
- Added an isolated environment for samtools. Previously it was using the default conda installation. Not really an issue, but might as well keep it's environment separate. Also added a temp() for the decoy removed bam file since we keep the bam produced from recal rule.
- Added a PIPELINE_VERSION in Snakefile. This value should be updated along with each git release. This value is also used in each SV report name (e.g. 3001A.wgs.sv.v0.9.0.2020-01-10.tsv). We may want to look into modifying cre to output files with report names.