### PR TITLE
add spliceai indel and snv annotations to crg2

### DIFF
--- a/vcfanno/crg.vcfanno.conf
+++ b/vcfanno/crg.vcfanno.conf
@@ -1,4 +1,17 @@
 [[annotation]]
+file = "spliceai_scores.raw.snv.hg19.vcf.gz"
+fields = ["SpliceAI"]
+names = ["spliceai_score"]
+ops = ["self"]
+
+[[annotation]]
+file = "spliceai_scores.raw.indel.hg19.vcf.gz"
+fields = ["SpliceAI"]
+names = ["spliceai_score"]
+ops = ["self"]
+
+
+[[annotation]]
 file="gnomad_exome.vcf.gz"
 fields=["AC","Hom","AF_POPMAX","AN"]
 names=["gnomad_ac_es","gnomad_hom_es","gnomad_af_es","gnomad_an_es"]


### PR DESCRIPTION
the following changes must also be made in cre:

`cre.gemini2txt.vcf2db.sh`
- add ` spliceai_score as spliceai_score,\`  to `sQuery`

`cre.vcf2db.R`
- add `'spliceai_score'` so it is selected in these functions:
     - `select_and_write2()` (line 367 or so) 
     - `clinical_report()` (line 757 or so)