### PR TITLE
ignore temp file deletions directives

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,9 +16,9 @@ tools:
 ref:
   name: GRCh37.75
   no_decoy_name: GRCh37
-  genome: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/GRCh37d5/GRCh37d5.fa
+  genome: /hpf/largeprojects/smital/smitalCCM/Reference/hg19/genome.fa
   known-variants: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/dbsnp.b147.20160601.tidy.vcf.gz
-  no_decoy: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/GRCh37/GRCh37.fa
+  no_decoy: /hpf/largeprojects/smital/smitalCCM/Reference/hg19/genome.fa
   decoy_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre/data/grch37d5.decoy.bed"
   canon_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/grch37.canon.bed"
 

--- a/config.yaml
+++ b/config.yaml
@@ -16,9 +16,9 @@ tools:
 ref:
   name: GRCh37.75
   no_decoy_name: GRCh37
-  genome: /hpf/largeprojects/smital/smitalCCM/Reference/hg19/genome.fa
+  genome: /hpf/largeprojects/smital/smitalCCM/bwa-index/genome.fa
   known-variants: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/dbsnp.b147.20160601.tidy.vcf.gz
-  no_decoy: /hpf/largeprojects/smital/smitalCCM/Reference/hg19/genome.fa
+  no_decoy: /hpf/largeprojects/smital/smitalCCM/bwa-index/genome.fa
   decoy_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre/data/grch37d5.decoy.bed"
   canon_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/grch37.canon.bed"
 

--- a/dnaseq_cluster.pbs
+++ b/dnaseq_cluster.pbs
@@ -9,9 +9,10 @@
 
 #please change the following three variables according to your settings, as the recent crg2 repo is not copied over here
 
-SF="/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/crg2/Snakefile" 
-CP="/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake"
-PBS="~/crg2/pbs_profile"
+
+SF=~/crg2/Snakefile; 
+CP="/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake";
+PBS=~/crg2/pbs_profile;
 
 source /hpf/largeprojects/ccmbio/aarthi/miniconda3/etc/profile.d/conda.sh
 conda activate /hpf/largeprojects/ccmbio/aarthi/miniconda3

--- a/dnaseq_cluster.pbs
+++ b/dnaseq_cluster.pbs
@@ -17,4 +17,4 @@ PBS=~/crg2/pbs_profile;
 source /hpf/largeprojects/ccmbio/aarthi/miniconda3/etc/profile.d/conda.sh
 conda activate /hpf/largeprojects/ccmbio/aarthi/miniconda3
 
-snakemake --use-conda -s $SF --conda-prefix $CP  --profile $PBS -p  
+snakemake --use-conda -s $SF --conda-prefix $CP  --profile $PBS -p  report/sv

--- a/parser.py
+++ b/parser.py
@@ -1,6 +1,15 @@
 import sys, os, subprocess
 from collections import namedtuple
 
+'''
+Parse three-column(family,sample,file-path) TSV file and sets up necessary directories, files as below:
+1. create family and decoy_rm directory
+2. symlink BAM files to deocy_rm
+3. copy config.yaml, pbs_config.yaml and dnaseq_cluster.pbs from crg2 repo and replace necessary string
+4. create units.tsv and samples.tsv for snakemake
+5. submit job if all the above goes well
+'''
+
 sample_sheet = sys.argv[1]
 path = sys.argv[2]
 crg2_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
@@ -13,16 +22,14 @@ def create_symlink(src, dest):
 def setup_directories(family, sample_list, filepath):
     d = os.path.join(filepath, family)
     if not os.path.isdir(d):
-        print(f"Creating project directory: {d}")
         os.mkdir(d)
 
     #copy config.yaml, pbs_config.yaml, and dnaseq_cluster.pbs
     for i in ["config.yaml", "pbs_profile/pbs_config.yaml", "dnaseq_cluster.pbs"]:
         cmd = ["cp", os.path.join(crg2_dir, i), d]
-        # print(f"copying {cmd}")
         subprocess.check_call(cmd)
 
-    #replace project ID in config.yaml
+    #replace family ID in config.yaml & dnaseq_cluster.pbs
     replace = 's/NA12878/{}/'.format(family)
     config = os.path.join(d,"config.yaml")
     if os.path.isfile(config):
@@ -37,7 +44,6 @@ def setup_directories(family, sample_list, filepath):
     #bam: start after remove_decoy 
     if len(sample_list) == len([i for i in sample_list if i.bam ]):
         decoy = os.path.join(d, "decoy_rm")
-        print(f"\tCreating dir {decoy}")
         if not os.path.isdir(decoy):
             os.mkdir(decoy)
             for i in sample_list:
@@ -48,21 +54,24 @@ def setup_directories(family, sample_list, filepath):
                     dest = dest + ".bai"
                     create_symlink(src, os.path.join(decoy, dest))
         else:
-            print(f"\t{decoy} directory already exists! Won't rewrite anything. ")
+            print(f"{decoy} directory already exists! Won't rewrite/submit jobs. ")
+            return False
+    return True
+
 
 def write_proj_files(sample_list, filepath):
     units, samples = os.path.join(filepath, "units.tsv"), os.path.join(filepath, "samples.tsv")
     with open(units, "w") as u, open(samples, "w") as s:
-        print(f"\tCreating files: units.tsv and samples.tsv")
-        u.writelines("sample\n")
-        s.writelines("sample\tunit\tplatform\tfq1\tfq2\tbam\n")
+        s.writelines("sample\n")
+        u.writelines("sample\tunit\tplatform\tfq1\tfq2\tbam\n")
         for i in sample_list:
-            s.writelines(f"{i.sample}\t{i.unit}\t{i.platform}\t{i.fq1}\t{i.fq2}\t{i.bam}\n")
-            u.writelines(f"{i.sample}\n")                
+            s.writelines(f"{i.sample}\n")
+            u.writelines(f"{i.sample}\t{i.unit}\t{i.platform}\t{i.fq1}\t{i.fq2}\t{i.bam}\n")
+            
 
 def submit_jobs(directory, family):
     if not os.path.isdir(directory):
-        print(f"\t{directory} not found. Exiting!")
+        print(f"{directory} not found. Exiting!")
         exit()
     pbs =  "dnaseq_cluster.pbs"
     if os.path.isfile(os.path.join(directory,pbs)):
@@ -70,14 +79,10 @@ def submit_jobs(directory, family):
         os.chdir(directory)
         cmd = ["qsub", pbs]
         jobid = subprocess.check_output(cmd).decode("UTF-8").rstrip()
-        print(f"\tSubmitted snakemake job for {family}: {jobid}")
+        print(f"Submitted snakemake job for {family}: {jobid}")
         os.chdir(cwd)
     else:
-        print(f"\t{pbs} not found. Copy the file from ~/crg2/ and run it manually")
-        
-
-    
-
+        print(f"{pbs} not found, not submitting jobs for {family}.")
 
 
 projects = {}
@@ -85,32 +90,34 @@ Units = namedtuple("Units", "sample unit platform fq1 fq2 bam")
 unit, platform = 1, "ILLUMINA"
 with open(sample_sheet) as f:
     for i in f:
-        family, sample, inp = i.strip().split("\t")
-        bam, fq1, fq2 = "", "", ""
-        if ".bam" in inp:
-            if os.path.isfile(inp):
-                bam = inp
-            else:
-                print(f"\tBAM: {inp} was not found! Exiting!")
-                exit()
-        elif ".fastq" in inp:
-            if "," in inp:
-                #multiple fastq
-                pass
-            else:
-                bpath = os.path.dirname(inp)
-                prefix, suffix = os.path.basename(inp).split("_R1")
-                r2 = os.path.join(bpath, prefix + "_R2" + suffix)
-                if os.path.isfile(r2) and os.path.isfile(inp):
-                    fq1, fq2 = inp, r2
+        if not i.startswith("familyID"):
+            family, sample, inp = i.strip().split("\t")
+            bam, fq1, fq2 = "", "", ""
+            if ".bam" in inp:
+                if os.path.isfile(inp):
+                    bam = inp
                 else:
-                    print(f"{inp} or {r2} was not found")
-        else:
-            print("Unhandled input type! exiting")
-            exit()
-        if not family in projects:
-            projects[family] = []
-        projects[family].append(Units(sample, unit, platform, fq1, fq2, bam))
+                    print(f"\tBAM: {inp} was not found! Exiting!")
+                    exit()
+            elif ".fastq" in inp:
+                if "," in inp:
+                    #multiple fastq
+                    pass
+                else:
+                    pass
+                    # bpath = os.path.dirname(inp)
+                    # prefix, suffix = os.path.basename(inp).split("_R1")
+                    # r2 = os.path.join(bpath, prefix + "_R2" + suffix)
+                    # if os.path.isfile(r2) and os.path.isfile(inp):
+                    #     fq1, fq2 = inp, r2
+                    # else:
+                    #     print(f"{inp} or {r2} was not found")
+            else:
+                print("Unhandled input type! Exiting")
+                exit()
+            if not family in projects:
+                projects[family] = []
+            projects[family].append(Units(sample, unit, platform, fq1, fq2, bam))
 
 for i in projects:
     
@@ -118,21 +125,13 @@ for i in projects:
     filepath = os.path.join(path,i)
 
     #create project directory
-    #copy config.yaml, dnaseq_cluster.pbs & replace project; copy pbs_config.yaml 
+    #copy config.yaml, dnaseq_cluster.pbs & replace family id; copy pbs_config.yaml 
     print(f"\nStarting to setup project directories for family: {i}")
-    setup_directories(i, sample_list, path)
+    submit_flag = setup_directories(i, sample_list, path)
     
-    #create samples.tsv & units.tsv
-    write_proj_files(sample_list, filepath)
-
-    #submit dnaseq_cluster.pbs
-    submit_jobs(filepath, i)
-
-    
-    
+    if submit_flag:
+        write_proj_files(sample_list, filepath)
+        submit_jobs(filepath, i)
 
 print("DONE")
-
-
-
 

--- a/parser.py
+++ b/parser.py
@@ -2,7 +2,8 @@ import sys, os, subprocess
 from collections import namedtuple
 
 '''
-Parse three-column(family,sample,file-path) TSV file and sets up necessary directories, files as below:
+Usage: python parser.py <input_sample.tsv> <absolute path to create directories> 
+Parse three-column(family,sample,file-path) TSV file (1st argument) and sets up necessary directories (under 2nd argument), files as below:
 1. create family and decoy_rm directory
 2. symlink BAM files to deocy_rm
 3. copy config.yaml, pbs_config.yaml and dnaseq_cluster.pbs from crg2 repo and replace necessary string

--- a/parser.py
+++ b/parser.py
@@ -3,44 +3,82 @@ from collections import namedtuple
 
 sample_sheet = sys.argv[1]
 path = sys.argv[2]
-crg2_dir = os.path.realpath(sys.argv[0])
+crg2_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
 def create_symlink(src, dest):
     if not os.path.isfile(dest):
-        print(f"symlinking {src} -> {dest}")
-        #subprocess.checkcall(["ln", "-s", src, dest])
+        cmd = ["ln", "-s", src, dest]
+        subprocess.check_call(cmd)
 
-def setup_directories(s, sample_list, filepath)
+def setup_directories(family, sample_list, filepath):
     d = os.path.join(filepath, family)
     if not os.path.isdir(d):
-        print(f"making dir {d}")
-        #os.mkdir(d)
+        print(f"Creating project directory: {d}")
+        os.mkdir(d)
+
     #copy config.yaml, pbs_config.yaml, and dnaseq_cluster.pbs
-    for i in ["config.yaml", "pbs_profile/pbs_config.yaml", "dnaseq_cluster.pbs"]
+    for i in ["config.yaml", "pbs_profile/pbs_config.yaml", "dnaseq_cluster.pbs"]:
         cmd = ["cp", os.path.join(crg2_dir, i), d]
-        print(f"copying {cmd}")
-        # subprocess.check_call(cmd)
-        
+        # print(f"copying {cmd}")
+        subprocess.check_call(cmd)
+
+    #replace project ID in config.yaml
+    replace = 's/NA12878/{}/'.format(family)
+    config = os.path.join(d,"config.yaml")
+    if os.path.isfile(config):
+        cmd = ["sed", "-i", replace, config]
+        subprocess.check_call(cmd)
+    replace = 's/crg2_pbs/{}/'.format(family)
+    pbs = os.path.join(d,"dnaseq_cluster.pbs")
+    if os.path.isfile(pbs):
+        cmd = ["sed", "-i", replace, pbs]
+        subprocess.check_call(cmd)
+
     #bam: start after remove_decoy 
     if len(sample_list) == len([i for i in sample_list if i.bam ]):
         decoy = os.path.join(d, "decoy_rm")
-        print(f"creating dir {deco}")
-        # os.mkdir(decoy)
-        for i in sample_list:
-            dest = "{}-{}.no_decoy_reads.bam".format(i.sample,i.unit)
-            create_symlink(i.bam, os.path.join(decoy, dest))
-            if os.path.isfile(i.bam + ".bai"):
-                dest = dest + ".bai"
-                create_symlink(src, os.path.join(decoy, dest))
+        print(f"\tCreating dir {decoy}")
+        if not os.path.isdir(decoy):
+            os.mkdir(decoy)
+            for i in sample_list:
+                dest = "{}-{}.no_decoy_reads.bam".format(i.sample,i.unit)
+                create_symlink(i.bam, os.path.join(decoy, dest))
+                if os.path.isfile(i.bam + ".bai"):
+                    src = i.bam + ".bai"
+                    dest = dest + ".bai"
+                    create_symlink(src, os.path.join(decoy, dest))
+        else:
+            print(f"\t{decoy} directory already exists! Won't rewrite anything. ")
 
 def write_proj_files(sample_list, filepath):
     units, samples = os.path.join(filepath, "units.tsv"), os.path.join(filepath, "samples.tsv")
-    with open(units, "w") as u and open(samples) as s:
+    with open(units, "w") as u, open(samples, "w") as s:
+        print(f"\tCreating files: units.tsv and samples.tsv")
         u.writelines("sample\n")
         s.writelines("sample\tunit\tplatform\tfq1\tfq2\tbam\n")
         for i in sample_list:
-            s.writelines(f"{i.sample}\t{i.unit}\t{i.platform}\{i.fq1}\t{i.fq2}\t{i.bam}\n")
+            s.writelines(f"{i.sample}\t{i.unit}\t{i.platform}\t{i.fq1}\t{i.fq2}\t{i.bam}\n")
             u.writelines(f"{i.sample}\n")                
+
+def submit_jobs(directory, family):
+    if not os.path.isdir(directory):
+        print(f"\t{directory} not found. Exiting!")
+        exit()
+    pbs =  "dnaseq_cluster.pbs"
+    if os.path.isfile(os.path.join(directory,pbs)):
+        cwd = os.getcwd()
+        os.chdir(directory)
+        cmd = ["qsub", pbs]
+        jobid = subprocess.check_output(cmd).decode("UTF-8").rstrip()
+        print(f"\tSubmitted snakemake job for {family}: {jobid}")
+        os.chdir(cwd)
+    else:
+        print(f"\t{pbs} not found. Copy the file from ~/crg2/ and run it manually")
+        
+
+    
+
+
 
 projects = {}
 Units = namedtuple("Units", "sample unit platform fq1 fq2 bam")
@@ -48,9 +86,13 @@ unit, platform = 1, "ILLUMINA"
 with open(sample_sheet) as f:
     for i in f:
         family, sample, inp = i.strip().split("\t")
-        bam, fq1, fq1 = "", "", ""
+        bam, fq1, fq2 = "", "", ""
         if ".bam" in inp:
-            bam = inp
+            if os.path.isfile(inp):
+                bam = inp
+            else:
+                print(f"\tBAM: {inp} was not found! Exiting!")
+                exit()
         elif ".fastq" in inp:
             if "," in inp:
                 #multiple fastq
@@ -64,7 +106,7 @@ with open(sample_sheet) as f:
                 else:
                     print(f"{inp} or {r2} was not found")
         else:
-            print("unhandled input type! exiting")
+            print("Unhandled input type! exiting")
             exit()
         if not family in projects:
             projects[family] = []
@@ -76,15 +118,20 @@ for i in projects:
     filepath = os.path.join(path,i)
 
     #create project directory
+    #copy config.yaml, dnaseq_cluster.pbs & replace project; copy pbs_config.yaml 
+    print(f"\nStarting to setup project directories for family: {i}")
     setup_directories(i, sample_list, path)
     
     #create samples.tsv & units.tsv
     write_proj_files(sample_list, filepath)
+
+    #submit dnaseq_cluster.pbs
+    submit_jobs(filepath, i)
+
     
-    #copy config.yaml & replace project: 
-    #copy dnaseq_cluster.pbs & pbs_config.yaml 
+    
 
-
+print("DONE")
 
 
 

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,91 @@
+import sys, os, subprocess
+from collections import namedtuple
+
+sample_sheet = sys.argv[1]
+path = sys.argv[2]
+crg2_dir = os.path.realpath(sys.argv[0])
+
+def create_symlink(src, dest):
+    if not os.path.isfile(dest):
+        print(f"symlinking {src} -> {dest}")
+        #subprocess.checkcall(["ln", "-s", src, dest])
+
+def setup_directories(s, sample_list, filepath)
+    d = os.path.join(filepath, family)
+    if not os.path.isdir(d):
+        print(f"making dir {d}")
+        #os.mkdir(d)
+    #copy config.yaml, pbs_config.yaml, and dnaseq_cluster.pbs
+    for i in ["config.yaml", "pbs_profile/pbs_config.yaml", "dnaseq_cluster.pbs"]
+        cmd = ["cp", os.path.join(crg2_dir, i), d]
+        print(f"copying {cmd}")
+        # subprocess.check_call(cmd)
+        
+    #bam: start after remove_decoy 
+    if len(sample_list) == len([i for i in sample_list if i.bam ]):
+        decoy = os.path.join(d, "decoy_rm")
+        print(f"creating dir {deco}")
+        # os.mkdir(decoy)
+        for i in sample_list:
+            dest = "{}-{}.no_decoy_reads.bam".format(i.sample,i.unit)
+            create_symlink(i.bam, os.path.join(decoy, dest))
+            if os.path.isfile(i.bam + ".bai"):
+                dest = dest + ".bai"
+                create_symlink(src, os.path.join(decoy, dest))
+
+def write_proj_files(sample_list, filepath):
+    units, samples = os.path.join(filepath, "units.tsv"), os.path.join(filepath, "samples.tsv")
+    with open(units, "w") as u and open(samples) as s:
+        u.writelines("sample\n")
+        s.writelines("sample\tunit\tplatform\tfq1\tfq2\tbam\n")
+        for i in sample_list:
+            s.writelines(f"{i.sample}\t{i.unit}\t{i.platform}\{i.fq1}\t{i.fq2}\t{i.bam}\n")
+            u.writelines(f"{i.sample}\n")                
+
+projects = {}
+Units = namedtuple("Units", "sample unit platform fq1 fq2 bam")
+unit, platform = 1, "ILLUMINA"
+with open(sample_sheet) as f:
+    for i in f:
+        family, sample, inp = i.strip().split("\t")
+        bam, fq1, fq1 = "", "", ""
+        if ".bam" in inp:
+            bam = inp
+        elif ".fastq" in inp:
+            if "," in inp:
+                #multiple fastq
+                pass
+            else:
+                bpath = os.path.dirname(inp)
+                prefix, suffix = os.path.basename(inp).split("_R1")
+                r2 = os.path.join(bpath, prefix + "_R2" + suffix)
+                if os.path.isfile(r2) and os.path.isfile(inp):
+                    fq1, fq2 = inp, r2
+                else:
+                    print(f"{inp} or {r2} was not found")
+        else:
+            print("unhandled input type! exiting")
+            exit()
+        if not family in projects:
+            projects[family] = []
+        projects[family].append(Units(sample, unit, platform, fq1, fq2, bam))
+
+for i in projects:
+    
+    sample_list = projects[i]
+    filepath = os.path.join(path,i)
+
+    #create project directory
+    setup_directories(i, sample_list, path)
+    
+    #create samples.tsv & units.tsv
+    write_proj_files(sample_list, filepath)
+    
+    #copy config.yaml & replace project: 
+    #copy dnaseq_cluster.pbs & pbs_config.yaml 
+
+
+
+
+
+

--- a/parser.py
+++ b/parser.py
@@ -1,26 +1,25 @@
 import sys, os, subprocess
 from collections import namedtuple
+import argparse
 
 '''
-Usage: python parser.py <input_sample.tsv> <absolute path to create directories> 
+Usage: python parser.py -f <input_sample.tsv> -d <absolute path to create directories> -s [mapped|recal|fastq|decoy_rm]
 Parse three-column(family,sample,file-path) TSV file (1st argument) and sets up necessary directories (under 2nd argument), files as below:
-1. create family and decoy_rm directory
-2. symlink BAM files to deocy_rm
+1. create family and directory passed as "-s"
+2. symlink BAM files if "-s" is not fastq
 3. copy config.yaml, pbs_config.yaml and dnaseq_cluster.pbs from crg2 repo and replace necessary string
 4. create units.tsv and samples.tsv for snakemake
 5. submit job if all the above goes well
 '''
 
-sample_sheet = sys.argv[1]
-path = sys.argv[2]
 crg2_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
-
+folder_file_suffix = {"mapped": "sorted.bam", "recal": "bam", "decoy_rm": "no_decoy_reads.bam"}
 def create_symlink(src, dest):
     if not os.path.isfile(dest):
         cmd = ["ln", "-s", src, dest]
         subprocess.check_call(cmd)
 
-def setup_directories(family, sample_list, filepath):
+def setup_directories(family, sample_list, filepath, step):
     d = os.path.join(filepath, family)
     if not os.path.isdir(d):
         os.mkdir(d)
@@ -42,23 +41,29 @@ def setup_directories(family, sample_list, filepath):
         cmd = ["sed", "-i", replace, pbs]
         subprocess.check_call(cmd)
 
-    #bam: start after remove_decoy 
-    if len(sample_list) == len([i for i in sample_list if i.bam ]):
-        decoy = os.path.join(d, "decoy_rm")
-        if not os.path.isdir(decoy):
-            os.mkdir(decoy)
-            for i in sample_list:
-                dest = "{}-{}.no_decoy_reads.bam".format(i.sample,i.unit)
-                create_symlink(i.bam, os.path.join(decoy, dest))
-                if os.path.isfile(i.bam + ".bai"):
-                    src = i.bam + ".bai"
-                    dest = dest + ".bai"
-                    create_symlink(src, os.path.join(decoy, dest))
-        else:
-            print(f"{decoy} directory already exists! Won't rewrite/submit jobs. ")
-            return False
-    return True
-
+    #bam: start after folder creation and symlink for step
+    if step in ["mapped", "decoy_rm", "recal" ]:
+        if len(sample_list) == len([i for i in sample_list if i.bam ]):
+            start_folder = os.path.join(d, step)
+            if not os.path.isdir(start_folder):
+                os.mkdir(start_folder)
+                for i in sample_list:
+                    dest = "{}-{}.{}".format(i.sample,i.unit,folder_file_suffix[step])
+                    create_symlink(i.bam, os.path.join(start_folder, dest))
+                    if os.path.isfile(i.bam + ".bai"):
+                        src = i.bam + ".bai"
+                        dest = dest + ".bai"
+                        create_symlink(src, os.path.join(start_folder, dest))
+            else:
+                print(f"{start_folder} directory already exists! Won't rewrite/submit jobs. ")
+                return False
+        return True
+    
+    #fastq: no directory creations required
+    if step == "fastq":
+        if len(sample_list) == len([i for i in sample_list if i.fq1 ]):
+            return True
+    
 
 def write_proj_files(sample_list, filepath):
     units, samples = os.path.join(filepath, "units.tsv"), os.path.join(filepath, "samples.tsv")
@@ -85,54 +90,120 @@ def submit_jobs(directory, family):
     else:
         print(f"{pbs} not found, not submitting jobs for {family}.")
 
+def valid_dir(dir):
 
-projects = {}
-Units = namedtuple("Units", "sample unit platform fq1 fq2 bam")
-unit, platform = 1, "ILLUMINA"
-with open(sample_sheet) as f:
-    for i in f:
-        if not i.startswith("familyID"):
-            family, sample, inp = i.strip().split("\t")
-            bam, fq1, fq2 = "", "", ""
-            if ".bam" in inp:
-                if os.path.isfile(inp):
-                    bam = inp
-                else:
-                    print(f"\tBAM: {inp} was not found! Exiting!")
-                    exit()
-            elif ".fastq" in inp:
-                if "," in inp:
-                    #multiple fastq
-                    pass
-                else:
-                    pass
-                    # bpath = os.path.dirname(inp)
-                    # prefix, suffix = os.path.basename(inp).split("_R1")
-                    # r2 = os.path.join(bpath, prefix + "_R2" + suffix)
-                    # if os.path.isfile(r2) and os.path.isfile(inp):
-                    #     fq1, fq2 = inp, r2
+    if os.path.isdir(dir):
+        return dir
+    else:
+        message = "{} path does not exist. Please provide absolute path".format(dir)
+        print(message)
+        raise argparse.ArgumentTypeError(message)
+
+def valid_file(filename):
+
+    if not os.path.isfile(filename):
+        message = "{} file does not exist".format(filename)
+        log_message(message)
+        raise argparse.ArgumentTypeError(message)
+    else:
+        if not os.path.getsize(filename) > 0:
+            message = "{} file is empty".format(filename)
+            print(message)
+            raise argparse.ArgumentTypeError(message)
+    return filename
+
+
+if __name__ == "__main__":
+    description = '''Reads sample info from TSV file (-f) and creates directory (-d) necessary to start
+    crg2 from step (-s) requested.
+    '''
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+            "-f",
+            "--file",
+            type=valid_file,
+            required=True,
+            help="Three column TAB-seperated sample info file",
+        )
+    parser.add_argument(
+            "-s",
+            "--step",
+            type=str,
+            required=True,
+            choices=["fastq", "mapped", "recal", "decoy_rm"],
+            help="start running from this folder creation(step)",
+        )
+    parser.add_argument(
+            "-d",
+            "--dir",
+            type=valid_dir,
+            required=True,
+            metavar="path",
+            help="Absolute path where crg2 directory struture will be created under familyID as base directory",
+        )
+    projects = {}
+    Units = namedtuple("Units", "sample unit platform fq1 fq2 bam")
+    unit, platform = 1, "ILLUMINA"
+    args = parser.parse_args()
+    with open(args.file) as f:
+        for i in f:
+            if not i.startswith("familyID"):
+                family, sample, inp = i.strip().split("\t")
+                bam, fq1, fq2 = "", "", ""
+                if ".bam" in inp:
+                    if os.path.isfile(inp):
+                        bam = inp
+                    else:
+                        print(f"\tBAM: {inp} was not found! Exiting!")
+                        exit()
+                elif any(s in inp for s in [".fastq", ".fq", ".fastq.gz", ".fq.gz"]):
+                    if "," in inp and len(inp.split(",")) == 2:
+                        #pair of fastq
+                        fq = inp.split(",")
+                        for item in fq:
+                            if "R1" in item:
+                                fq1 = item
+                            elif "R2" in item:
+                                fq2 = item
+                            else:
+                                pass
+                        if os.path.isfile(fq1) and os.path.isfile(fq2):
+                            fq1, fq2 = fq1, fq2
+                        else:
+                            print(f"\tFASTQ: {fq1} or {fq2} were not found.")
+                            print(f"\tExpects one FASTQ per end and comma-seperated as the 3rd column")
+                            print(f"\tIf each end is split across multiple file, concatenate them manually")
+                            print(f"\tfirst, and pass the concatenated fastq file pairs here. Exiting!" )
+                            exit()
                     # else:
-                    #     print(f"{inp} or {r2} was not found")
-            else:
-                print("Unhandled input type! Exiting")
-                exit()
-            if not family in projects:
-                projects[family] = []
-            projects[family].append(Units(sample, unit, platform, fq1, fq2, bam))
+                        # pass
+                        # bpath = os.path.dirname(inp)
+                        # prefix, suffix = os.path.basename(inp).split("_R1")
+                        # r2 = os.path.join(bpath, prefix + "_R2" + suffix)
+                        # if os.path.isfile(r2) and os.path.isfile(inp):
+                        #     fq1, fq2 = inp, r2
+                        # else:
+                        #     print(f"{inp} or {r2} was not found")
+                else:
+                    print("Unhandled input type! Exiting")
+                    exit()
+                if not family in projects:
+                    projects[family] = []
+                projects[family].append(Units(sample, unit, platform, fq1, fq2, bam))
 
-for i in projects:
-    
-    sample_list = projects[i]
-    filepath = os.path.join(path,i)
+    for i in projects:
+        
+        sample_list = projects[i]
+        filepath = os.path.join(args.dir,i)
 
-    #create project directory
-    #copy config.yaml, dnaseq_cluster.pbs & replace family id; copy pbs_config.yaml 
-    print(f"\nStarting to setup project directories for family: {i}")
-    submit_flag = setup_directories(i, sample_list, path)
-    
-    if submit_flag:
-        write_proj_files(sample_list, filepath)
-        submit_jobs(filepath, i)
+        #create project directory
+        #copy config.yaml, dnaseq_cluster.pbs & replace family id; copy pbs_config.yaml 
+        print(f"\nStarting to setup project directories for family: {i}")
+        submit_flag = setup_directories(i, sample_list, args.dir, args.step)
+        
+        if submit_flag:
+            write_proj_files(sample_list, filepath)
+            # submit_jobs(filepath, i)
 
-print("DONE")
+    print("DONE")
 

--- a/parser.py
+++ b/parser.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
         
         if submit_flag:
             write_proj_files(sample_list, filepath)
-            # submit_jobs(filepath, i)
+            submit_jobs(filepath, i)
 
     print("DONE")
 

--- a/pbs_profile/cluster.md
+++ b/pbs_profile/cluster.md
@@ -16,8 +16,7 @@ pbs_profile is the profile folder with all the relevant files and settings for P
 ```
 The above files for the profile were adapted from https://github.com/Snakemake-Profiles/generic and https://github.com/Snakemake-Profiles/pbs-torque
 
-Once the above files are in place, you can dry-run Snakemake by passing the absolute location of the profile folder. Make sure the value of `cluster-config` is set to absolute path inside the `config.yaml` file. 
-`cluster-config: "/home/<username>/crg2/pbs_profile/pbs_config.yaml"`
+Copy the `pbs_config.yaml` file to the directory you wish to start Snakemake (this is expected to be in current path, just like the main crg2/config.yaml). Run Snakemake in dry-run mode by passing the absolute location of the profile folder as below,
 
 ```bash
 snakemake --use-conda -s ~/crg2/Snakefile --conda-prefix /hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake --profile ~/crg2/pbs_profile -nr
@@ -40,4 +39,4 @@ B. Setting `immediate_submit=true` in 'config.yaml' along with passing `--depend
     2. The main Snakemake process exits immediately, so there is no process to track output file presence before consequent job submission, monitor jobs and resubmit if failure happens. 
 Therefore, setting 'immediate_submission=false' and not passing '--depend' will work best for our scenario. 
 
-C.`pbs_submit.py` script prioritizes (mem and thread) options set in `pbs_config.yaml` over resources set inside ".smk" files. This would only affect the resources when submitting job, not the threads in actual program execution. May have to test for every case and rethink if this is not desired.  
+C.`pbs_submit.py` script prioritizes (mem and thread) options set in `pbs_config.yaml` over resources set inside ".smk" files. This would only affect the resources when submitting job, not the threads in actual program execution. May have to test for every case and rethink if this is not desired.

--- a/pbs_profile/config.yaml
+++ b/pbs_profile/config.yaml
@@ -4,7 +4,7 @@ cluster: "pbs_submit.py"
 #set immediate-submit:true.
 
 cluster-status: "pbs_status.py" #
-cluster-config: "/home/amohan/crg2/pbs_profile/pbs_config.yaml"
+cluster-config: "pbs_config.yaml" #copy this from crg2/pbs_profile/ to the directory running snakemake
 jobscript: "pbs_jobscript.sh"
 max-jobs-per-second: 10
 max-status-checks-per-second: 1

--- a/pbs_profile/config.yaml
+++ b/pbs_profile/config.yaml
@@ -13,7 +13,7 @@ local-cores: 1
 rerun-incomplete: true  # recommended for cluster submissions
 restart-times: 3
 keep-going: false
-notemp: false
+notemp: true
 immediate-submit: false
 latency-wait: 60
 verbose: true

--- a/pbs_profile/pbs_config.yaml
+++ b/pbs_profile/pbs_config.yaml
@@ -40,3 +40,6 @@ svscore:
 allsnvreport:
   mem: "60g"
   mail: "ae"
+
+smoove:
+  mem: "70g"

--- a/pbs_profile/pbs_config.yaml
+++ b/pbs_profile/pbs_config.yaml
@@ -42,10 +42,10 @@ allsnvreport:
   mail: "ae"
 
 wham:
-  mem: "70g"
+  mem: "100g"
 
 smoove:
-  mem: "70g"
+  mem: "100g"
 
 manta:
-  mem: "70g"
+  mem: "100g"

--- a/pbs_profile/pbs_config.yaml
+++ b/pbs_profile/pbs_config.yaml
@@ -46,3 +46,6 @@ wham:
 
 smoove:
   mem: "70g"
+
+manta:
+  mem: "70g"

--- a/pbs_profile/pbs_config.yaml
+++ b/pbs_profile/pbs_config.yaml
@@ -41,5 +41,8 @@ allsnvreport:
   mem: "60g"
   mail: "ae"
 
+wham:
+  mem: "70g"
+
 smoove:
   mem: "70g"

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -73,7 +73,7 @@ rule remove_decoy:
         bam = "recal/{sample}-{unit}.bam",
         canon = config["ref"]["canon_bed"],
     output:
-        out_f = temp("decoy_rm/{sample}-{unit}.no_decoy_reads.bam")
+        out_f = protected("decoy_rm/{sample}-{unit}.no_decoy_reads.bam")
     log:
         "logs/remove_decoys/{sample}-{unit}.log"
     threads: 8

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -18,7 +18,7 @@ rule map_reads:
     input:
         reads = get_fastq
     output:
-        temp("mapped/{sample}-{unit}.sorted.bam")
+        "mapped/{sample}-{unit}.sorted.bam"
     log:
         "logs/bwa_mem/{sample}-{unit}.log"
     params:

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -12,7 +12,7 @@ rule fastqc:
 
 rule samtools_stats:
     input:
-        "recal/{sample}-{unit}.bam"
+        "decoy_rm/{sample}-{unit}.no_decoy_reads.bam"
     output:
         "qc/samtools-stats/{sample}-{unit}.txt"
     log:
@@ -38,8 +38,8 @@ rule fastq_screen:
 
 rule qualimap:
     input: 
-        bam = "mapped/{sample}-{unit}.sorted.bam", 
-        bai = "mapped/{sample}-{unit}.sorted.bam.bai"
+        bam = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam", 
+        bai = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam.bai"
     output:
         "qc/qualimap/{sample}-{unit}/genome_results.txt",
         "qc/qualimap/{sample}-{unit}/qualimapReport.html",
@@ -62,9 +62,9 @@ rule qualimap:
 
 rule verifybamid2:
     input:
-        bam = "mapped/{sample}-{unit}.sorted.bam",
+        bam = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam",
         ref = config["ref"]["no_decoy"],
-        bai = "mapped/{sample}-{unit}.sorted.bam.bai"
+        bai = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam.bai"
     output:
         sm = "qc/verifybamid2/{sample}-{unit}.selfSM",
     log:
@@ -80,17 +80,13 @@ rule verifybamid2:
 rule multiqc:
     input:
         [expand(input_file, u=units.itertuples()) for input_file in ["qc/samtools-stats/{u.sample}-{u.unit}.txt", 
-                                                            "qc/fastqc/{u.sample}-{u.unit}.zip",
-                                                            "qc/fastqc/{u.sample}-{u.unit}.zip", 
-                                                            "qc/dedup/{u.sample}-{u.unit}.metrics.txt", 
                                                             "qc/verifybamid2/{u.sample}-{u.unit}.selfSM", 
                                                             "qc/qualimap/{u.sample}-{u.unit}/genome_results.txt", 
                                                             "qc/qualimap/{u.sample}-{u.unit}/raw_data_qualimapReport/coverage_histogram.txt",
                                                             "qc/qualimap/{u.sample}-{u.unit}/qualimapReport.html", 
                                                             "qc/qualimap/{u.sample}-{u.unit}/raw_data_qualimapReport/genome_fraction_coverage.txt", 
                                                             "qc/qualimap/{u.sample}-{u.unit}/raw_data_qualimapReport/mapped_reads_gc-content_distribution.txt",
-                                                            "qc/qualimap/{u.sample}-{u.unit}/raw_data_qualimapReport/mapped_reads_gc-content_distribution.txt", 
-                                                            "qc/fastq_screen/{u.sample}-{u.unit}_screen.txt"
+                                                            "qc/qualimap/{u.sample}-{u.unit}/raw_data_qualimapReport/mapped_reads_gc-content_distribution.txt"
                                                                     ]]
     params:
     output:

--- a/rules/sv.smk
+++ b/rules/sv.smk
@@ -80,7 +80,7 @@ rule metasv:
     threads:
         4
     output:
-        temp("sv/metasv/{sample}-{unit}/variants.vcf.gz")
+        "sv/metasv/{sample}-{unit}/variants.vcf.gz"
     log:
         "logs/metasv/{sample}-{unit}.log"
     wrapper:
@@ -91,7 +91,7 @@ rule snpeff:
     input:
         "sv/metasv/{sample}-{unit}/variants.pass.vcf.gz"
     output:
-        vcf = temp("sv/metasv/{sample}-{unit}/variants.snpeff.vcf"),
+        vcf = "sv/metasv/{sample}-{unit}/variants.snpeff.vcf",
         report = report("sv/metasv/{sample}-{unit}/snpEff_summary.html",caption="../report/snpeff.rst",category="SnpEff")
     log:
         "logs/snpeff/{sample}-{unit}.log"

--- a/rules/sv.smk
+++ b/rules/sv.smk
@@ -54,13 +54,13 @@ rule smoove:
         bai = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam.bai",
         fasta = config["ref"]["no_decoy"]
     params:
-        outdir = "sv/smoove",
+        outdir = "sv/smoove/{sample}-{unit}/",
         name = "{sample}-{unit}",
         exclude_chroms = ",".join([c for c in get_contigs().tolist() if is_nonalt(c) == False])
     threads:
        4
     output:
-        "sv/smoove/{sample}-{unit}-smoove.genotyped.vcf.gz"
+        "sv/smoove/{sample}-{unit}/{sample}-{unit}-smoove.genotyped.vcf.gz"
     log:
         "logs/smoove/{sample}-{unit}.log"
     wrapper:
@@ -73,7 +73,7 @@ rule metasv:
         fasta = config["ref"]["no_decoy"],
         manta = "sv/manta/{sample}-{unit}/results/variants/diploidSV.vcf.gz",
         wham = "sv/wham/{sample}-{unit}.wham.vcf",
-        lumpy = "sv/smoove/{sample}-{unit}-smoove.genotyped.vcf.gz"
+        lumpy = "sv/smoove/{sample}-{unit}/{sample}-{unit}-smoove.genotyped.vcf.gz"
     params:
         sample = "{sample}-{unit}",
         outdir = "sv/metasv/{sample}-{unit}"

--- a/rules/sv.smk
+++ b/rules/sv.smk
@@ -1,7 +1,7 @@
 rule manta:
     input:
-        bam = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam",
-        bai = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam.bai",
+        bam = "mapped/{sample}-{unit}.sorted.bam",
+        bai = "mapped/{sample}-{unit}.sorted.bam.bai",
         fasta = config["ref"]["no_decoy"]
     params:
         outdir = directory("sv/manta/{sample}-{unit}/"),
@@ -18,8 +18,8 @@ rule manta:
 
 rule wham:
     input:
-        bam = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam",
-        bai = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam.bai",
+        bam = "mapped/{sample}-{unit}.sorted.bam",
+        bai = "mapped/{sample}-{unit}.sorted.bam.bai",
         fasta = config["ref"]["no_decoy"]
     params:
         include_chroms = ",".join(
@@ -50,8 +50,8 @@ rule smoove:
     #added param for --outdir and use in the shell to delete the intermediary files with 'rm'
     #changed --name param to include only name
     input:
-        bam = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam",
-        bai = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam.bai",
+        bam = "mapped/{sample}-{unit}.sorted.bam",
+        bai = "mapped/{sample}-{unit}.sorted.bam.bai",
         fasta = config["ref"]["no_decoy"]
     params:
         outdir = "sv/smoove/{sample}-{unit}/",
@@ -68,8 +68,8 @@ rule smoove:
 
 rule metasv:
     input:
-        bam = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam",
-        bai = "decoy_rm/{sample}-{unit}.no_decoy_reads.bam.bai",
+        bam = "mapped/{sample}-{unit}.sorted.bam",
+        bai = "mapped/{sample}-{unit}.sorted.bam.bai",
         fasta = config["ref"]["no_decoy"],
         manta = "sv/manta/{sample}-{unit}/results/variants/diploidSV.vcf.gz",
         wham = "sv/wham/{sample}-{unit}.wham.vcf",

--- a/wrappers/smoove/wrapper.py
+++ b/wrappers/smoove/wrapper.py
@@ -2,7 +2,10 @@ from snakemake.shell import shell
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-
+if snakemake.params.exclude_chroms:
+    excludechroms = "--excludechroms {}".format(snakemake.params.exclude_chroms)
+else:
+    excludechroms = ""
 shell(
     "(smoove call -x "
     "--name {snakemake.params.name} "
@@ -10,7 +13,7 @@ shell(
     "--fasta {snakemake.input.fasta} "
     "-p {snakemake.threads} "
     "--genotype "
-    "--excludechroms {snakemake.params.exclude_chroms} "
+    "{excludechroms} "
     "{snakemake.input.bam}) {log}; "
     "cd {snakemake.params.outdir}; "
     "rm *.bam* *.histo ;"


### PR DESCRIPTION
- [x] disable temp file deletions by setting 
```
pbs_profile/config.yaml:
notemp: true
```
- [x] remove `temp` directive for outputs from "remove_decoy" to "svreport" steps
- [x] pipeline starts after "remove_decoy" step for most samples; so make the output of this step `protected`
- [x] write a bash/py script to parse sample sheets and do the following: 
1. create directories, and symlink files
2. copy `config.yaml` and `pbs_config.yaml` files to the above directory
3. populate family/sample info to `config.yaml`, `units.tsv`, `samples.tsv` and `dnaseq_cluster.pbs`
4. update "hpo" in `config.yaml`?
5. maybe do auto submission?

- [x] check for chromosome naming in "snpeff"
- [x] add unfiltered sv report functionality
- [x] change value of "no_decoy" and "genome" in `config.yaml`

For the last batch of samples with FASTQ as input, make the following changes before processing: 
- [x] add option for starting point to 'parser.py' 
- [x] check for fasta and bwa index (change them in config.yaml)
- [x] remove temp deletions for folders: `fastq` `mapped` `recal` `decoy_rm`
- [ ] 