### PR TITLE
Upgrade vep to v104

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -52,9 +52,9 @@ annotation:
     lua_script: "~/crg2/vcfanno/crg.vcfanno.lua"
     base_path: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/"
   vep:
-    dir: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/26de2304/share/ensembl-vep-100.4-0/"
+    dir: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/6f4af8a1/share/ensembl-vep-104.0-0/"
     dir_cache: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/vep/"
-    maxentscan: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/26de2304/share/ensembl-vep-100.4-0/maxEntScan/"
+    maxentscan: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/6f4af8a1/share/ensembl-vep-104.0-0/maxEntScan/"
     human_ancestor_fasta: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/human_ancestor.fa.gz"
   snpeff:
     dataDir: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/snpeff"

--- a/wrappers/vep/environment.yaml
+++ b/wrappers/vep/environment.yaml
@@ -1,5 +1,5 @@
 channels:
   - bioconda
 dependencies:
-  - ensembl-vep =100.4
+  - ensembl-vep =104.0
   - bcftools =1.9


### PR DESCRIPTION
Environment for vep v104 is now installed on the hpf (/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/6f4af8a1/share/ensembl-vep-104.0-0/)