### PR TITLE
fix bug fastq_prep vs bamtofastq issue

### DIFF
--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -1,5 +1,4 @@
 ruleorder: bamtofastq > fastq_prep
-ruleorder: gzip_fastq > fastq_prep
 
 
 rule bamtofastq:
@@ -9,15 +8,15 @@ rule bamtofastq:
         outdir = temp("fastq/"),
         sort_check = True
     output:
-        fastq1 = temp("fastq/{family}_{sample}_R1.fastq"),
-        fastq2 = temp( "fastq/{family}_{sample}_R2.fastq")
+        fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
+        fastq2 = temp( "fastq/{family}_{sample}_R2.fastq.gz")
     log:
         "logs/bamtofastq/{family}_{sample}.log"
     threads:
         4
     wrapper:
         get_wrapper_path("bedtools", "bamtofastq")
-        
+
 
 rule fastq_prep:
     input: 
@@ -111,12 +110,3 @@ rule samtools_index:
     wrapper:
         get_wrapper_path("samtools", "index")
 
-rule gzip_fastq:
-    input:
-        "{prefix}.fastq"
-    output:
-        "{prefix}.fastq.gz"
-    shell:
-        """
-        gzip {input}
-        """

--- a/wrappers/bedtools/bamtofastq/wrapper.py
+++ b/wrappers/bedtools/bamtofastq/wrapper.py
@@ -28,9 +28,11 @@ if snakemake.params.sort_check:
         bamtofastq_cmd = (
             " bedtools bamtofastq -i /dev/stdin "
             "-fq {snakemake.output.fastq1} "
-            "-fq2 {snakemake.output.fastq2}"
+            "-fq2 {snakemake.output.fastq2}; "
         )
 
-shell(
-    "(" + sort_cmd + bamtofastq_cmd + ") {log}"
-)
+        fq1_gzip_cmd = " gzip {snakemake.output.fastq1}; "
+
+        fq2_gzip_cmd = " gzip {snakemake.output.fastq2}; "
+
+shell("(" + sort_cmd + bamtofastq_cmd + fq1_gzip_cmd + fq2_gzip_cmd + ") {log}")


### PR DESCRIPTION
When the input was fastq, snakemake would execute bamtofastq, resulting in errors. Incorporating the gzip fastq step into bamtofastq  seems to avoid that issue.