### PR TITLE
HPO to panel bed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Make sure to replace ```~/crg2-conda``` with the path made in step 4. This will 
   - set ```-reciprocal             yes```
   - set ```-svtBEDcol:     4```
 
+10. To generate a gene panel from an HPO text file exported from PhenomeCentral or G4RD, add the HPO filepath to config["run"]["hpo"]. You will also need to generate Ensembl and RefSeq gene files as well as an HGNC gene mapping file.
+- Download and unzip Ensembl gtf: ```wget -qO- http://ftp.ensembl.org/pub/grch37/current/gtf/homo_sapiens/Homo_sapiens.GRCh37.87.gtf.gz  | gunzip -c > Homo_sapiens.GRCh37.87.gtf```
+- Download and unzip RefSeq gff: ```wget https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh37_latest/refseq_identifiers/GRCh37_latest_genomic.gff.gz | gunzip -c > GRCh37_latest_genomic.gff```
+- Download RefSeq chromosome mapping file: ```wget https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh37_latest/refseq_identifiers/GRCh37_latest_assembly_report.txt```
+- Run script to parse the above files: ```python scripts/clean_gtf.py --ensembl_gtf /path/to/Homo_sapiens.GRCh37.87.gtf --refseq_gff3 /path/to/GRCh37_latest_genomic.gff --refseq_assembly /path/to/GRCh37_latest_assembly_report.txt```
+- Add the paths to the output files, Homo_sapiens.GRCh37.87.gtf_subset.csv and GRCh37_latest_genomic.gff_subset.csv, to the config["gene"]["ensembl"] and config["gene"]["refseq"] fields.
+- You will also need the HGNC alias file: download this from https://www.genenames.org/download/custom/ using the default fields. Add the path this file to config["gene"]["hgnc"].
 ## Running the pipeline
 1. Make a folder in a directory with sufficient space. Copy over the template files samples.tsv, units.tsv, config.yaml.
 You may need to re-copy config.yaml and pbs_config.yaml if the files were recently updated in repo from previous crg2 runs. Note that 'pbs_config.yaml' is for submitting each rule as cluster jobs, so ignore this if not running on cluster

--- a/Snakefile
+++ b/Snakefile
@@ -6,16 +6,15 @@ include: "rules/common.smk"
 import datetime
 rule all:
     input:
-        expand("report/{p}/{family}", p=["panel", "panel-flank"], family=config["run"]["project"]) if config["run"]["panel"] else [],
+        expand("report/{p}/{family}", p=["panel", "panel-flank"], family=config["run"]["project"]) if config["run"]["hpo"] or config["run"]["panel"]  else [],
         expand("report/{p}/{family}", p=["denovo"], family=config["run"]["project"]) if config["run"]["ped"] else [],
-        expand("report/{p}/{family}", p=["panel", "panel-flank", "denovo"], family=config["run"]["project"]) if config["run"]["panel"] and config["run"]["ped"] else [],
+        expand("report/{p}/{family}", p=["panel", "panel-flank", "denovo"], family=config["run"]["project"]) if (config["run"]["hpo"] or config["run"]["panel"]) and config["run"]["ped"] else [],
         "report/coding/{family}".format(family=config["run"]["project"]),
         "report/sv",
         "report/str/{family}.EH-v1.1.xlsx".format(family=config["run"]["project"]),
         "qc/multiqc/multiqc.html",
         #"plots/depths.svg",
         #"plots/allele-freqs.svg"
-        "genes/genes.bed" if config["run"]["hpo"] else [],
         "programs-{}.txt".format(PIPELINE_VERSION)
 
 localrules: write_version

--- a/Snakefile
+++ b/Snakefile
@@ -15,6 +15,7 @@ rule all:
         "qc/multiqc/multiqc.html",
         #"plots/depths.svg",
         #"plots/allele-freqs.svg"
+        "genes/genes.bed" if config["run"]["hpo"] else [],
         "programs-{}.txt".format(PIPELINE_VERSION)
 
 localrules: write_version

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,11 @@ run:
   hpo: "" # five-column TSV with HPO terms; leave this string empty is there are no hpo terms
   flank: 100000
 
+genes:
+  ensembl: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/Homo_sapiens.GRCh37.87.gtf_subset.csv"
+  refseq: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/GRCh37_latest_genomic.gff_subset.csv" 
+  hgnc: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/HGNC_20210617.txt"
+
 tools:
   svscore_script: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/SVScore/svscore.pl"
   annotsv: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/AnnotSV_2.1"

--- a/envs/hpo_to_panel.yaml
+++ b/envs/hpo_to_panel.yaml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python >3.5
+  - pyranges
+  - pybedtools

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -32,13 +32,35 @@ rule allsnvreport:
          unset type
          fi;
          '''
-if config["run"]["panel"]:
+if config["run"]["hpo"]:
+
+    def get_panel(wildcards):
+        if not config["run"]["panel"]:
+            return "genes/genes.bed"
+        return config["run"]["panel"]
 
     def get_bed(wildcards):
         if wildcards.p == "panel-flank":
             return "{}-flank-{}k.bed".format(config["run"]["project"], int(config["run"]["flank"]/1000))
-        else:
-            return config["run"]["panel"]
+        return get_panel()
+
+
+    rule hpo_to_panel:
+        input: 
+            hpo=config["run"]["hpo"],
+            ensembl=config["genes"]["ensembl"],
+            refseq=config["genes"]["refseq"],
+            hgnc=config["genes"]["hgnc"]
+        params: 
+            crg2=config["tools"]["crg2"],
+            cre=config["tools"]["cre"]
+        output: 
+            genes="genes/genes.bed"
+        conda: "../envs/hpo_to_panel.yaml"
+        log:
+            "logs/hpo_to_panel/genes.log"
+        script:
+            "../scripts/hpo_to_panel.py"
 
     rule add_flank:
         input: config["run"]["panel"]

--- a/scripts/clean_gtf.py
+++ b/scripts/clean_gtf.py
@@ -1,0 +1,96 @@
+"""
+Takes and cleans ensembl and refseq gtfs and gffs respectively (GRCh37), saving them as csvs.
+wget -qO- http://ftp.ensembl.org/pub/grch37/current/gtf/homo_sapiens/Homo_sapiens.GRCh37.87.gtf.gz  | gunzip -c > Homo_sapiens.GRCh37.87.gtf
+wget https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh37_latest/refseq_identifiers/GRCh37_latest_genomic.gff.gz | gunzip -c > GRCh37_latest_genomic.gff
+wget https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh37_latest/refseq_identifiers/GRCh37_latest_assembly_report.txt
+Source: https://github.com/ccmbioinfo/sampletracker2stager/blob/master/variants/clean_gtf.py, Delvin So
+"""
+
+import pandas as pd
+import argparse
+import pyranges
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--ensembl_gtf",
+        type=str,
+        help="unzipped ensembl gtf file",
+    )
+    parser.add_argument(
+        "--refseq_gff3",
+        type=str,
+        help="unzipped refseq gff file",
+    )
+    parser.add_argument(
+        "--refseq_assembly",
+        type=str,
+        help="refseq assembly report",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+
+    args = get_parser().parse_args()
+
+    # clean ensembl gtf
+    ensembl = pyranges.read_gtf(args.ensembl_gtf)
+
+    ensembl_ss = ensembl[(ensembl.Feature == "gene")]
+    ensembl_ss = ensembl_ss[~(ensembl_ss.Chromosome.str.startswith("GL"))]
+
+    ensembl_df = ensembl_ss.df[
+        ["Chromosome", "Start", "End", "Source", "gene_id"]
+    ].copy()
+    ensembl_df.columns = map(str.lower, ensembl_df.columns)
+    ensembl_df = ensembl_df.rename(columns={"gene_id": "name"})
+
+    ensembl_df.to_csv("Homo_sapiens.GRCh37.87.gtf_subset.csv", index=False)
+
+    # clean refseq gff (for some reason gtf throws errors with pyranges)
+    refseq = pyranges.read_gff3(args.refseq_gff3)
+
+    refseq_ss = refseq[(refseq.Feature == "gene")]
+    refseq_df = refseq_ss.df[["Chromosome", "Start", "End", "Source", "Name"]].copy()
+    refseq_df.columns = map(str.lower, refseq_df.columns)
+    refseq_df.rename(columns={"chromosome": "chromosome_refseq"}, inplace=True)
+
+    # map refseq chromosomes (e.g. accession NC_000001.10 refers to chr1)
+    assembly = pd.read_csv(
+        args.refseq_assembly,
+        sep="\t",
+        comment="#",
+        names=[
+            "Sequence-Name",
+            "Sequence-Role",
+            "Assigned-Molecule",
+            "Assigned-Molecule-Location/Type",
+            "GenBank-Accn",
+            "Relationship",
+            "RefSeq-Accn",
+            "Assembly-Unit",
+            "Sequence-Length",
+            "UCSC-style-name",
+        ],
+    )
+    assembly = assembly[["RefSeq-Accn", "Sequence-Name"]]
+    chrom_dict = {}
+    for accn, chr in zip(assembly["RefSeq-Accn"], assembly["Sequence-Name"]):
+        chrom_dict[accn] = chr
+
+    refseq_df["chromosome"] = [
+        chrom_dict[accn] for accn in refseq_df["chromosome_refseq"].values
+    ]
+
+    # remove non-canonical chromosomes
+    chrom = [str(i) for i in range(1, 23)] + ["MT", "X", "Y"]
+    refseq_df = refseq_df[refseq_df["chromosome"].isin(chrom)]
+
+    refseq_df = refseq_df.drop(columns=["chromosome_refseq"])
+    refseq_df = refseq_df[["chromosome", "start", "end", "source", "name"]]
+
+    refseq_df.to_csv("GRCh37_latest_genomic.gff_subset.csv", index=False)
+
+    print("Done")

--- a/scripts/hpo_to_panel.py
+++ b/scripts/hpo_to_panel.py
@@ -24,7 +24,7 @@ def query_alias(aliases, gene):
         return False
 
 
-def main(hpo, ensembl, refseq, hgnc):
+def main(family, hpo, ensembl, refseq, hgnc):
     logfile = "logs/hpo_to_panel/genes.log"
     logging.basicConfig(
         filename=logfile,
@@ -98,13 +98,16 @@ def main(hpo, ensembl, refseq, hgnc):
     bed = bed.sort().merge()
     bed_df = bed.to_dataframe()
     log_message("Outputting sorted and merged bed file")
-    bed_df.to_csv("genes/genes.bed", sep="\t", header=False, index=False)
+    if not os.path.isdir("genes"):
+        os.mkdir("genes")
+    bed_df.to_csv(f"genes/{family}.bed", sep="\t", header=False, index=False)
     os.remove("genes/temp.bed")
 
 
 if __name__ == "__main__":
+    family = snakemake.wildcards.family
     hpo = snakemake.input.hpo
     ensembl = snakemake.input.ensembl
     refseq = snakemake.input.refseq
     hgnc = snakemake.input.hgnc
-    main(hpo, ensembl, refseq, hgnc)
+    main(family, hpo, ensembl, refseq, hgnc)

--- a/scripts/hpo_to_panel.py
+++ b/scripts/hpo_to_panel.py
@@ -1,0 +1,110 @@
+import pandas as pd
+import pybedtools
+import logging, os
+
+
+def log_message(*message):
+    """write message to logfile and stdout"""
+    if message:
+        for i in message:
+            logging.info(i)
+            print(i)
+
+
+def query_alias(aliases, gene):
+    """check if gene is in list of aliases"""
+    # check if value is nan
+    if aliases == aliases:
+        aliases = [alias.replace(" ", "") for alias in aliases]
+        if gene in aliases:
+            return True
+        else:
+            return False
+    else:
+        return False
+
+
+def main(hpo, ensembl, refseq, hgnc):
+    logfile = "logs/hpo_to_panel/genes.log"
+    logging.basicConfig(
+        filename=logfile,
+        filemode="w",
+        level=logging.DEBUG,
+        format="%(asctime)s:%(message)s",
+        datefmt="%Y-%m-%d %H:%M",
+    )
+
+    log_message("Loading gene coordinates and aliases")
+    hpo = pd.read_csv(hpo, sep="\t", comment="#").set_index("Gene ID")
+    ensembl = pd.read_csv(ensembl).astype(str).set_index("name")
+    refseq = pd.read_csv(refseq).astype(str).set_index("name")
+    hgnc = pd.read_csv(hgnc, sep="\t")
+    genes = pd.concat([ensembl, refseq])
+
+    # join hpo terms and ensembl+refseq genes on gene id (most gene ids in the hpo file are ENSG ids, but not all)
+    log_message("Mapping HPO genes to gene coordinates")
+    hpo_coord = genes.join(hpo, how="inner").reset_index()
+    missing = [gene for gene in hpo.index if gene not in hpo_coord["index"].values]
+
+    # check missing genes against HGNC previous symbols and aliases
+    log_message("Mapping missing genes to HGNC aliases")
+    hgnc["Alias symbols"] = hgnc["Alias symbols"].apply(
+        lambda x: x.split(",") if x == x else x
+    )
+    hgnc["Previous symbols"] = hgnc["Previous symbols"].apply(
+        lambda x: x.split(",") if x == x else x
+    )
+    alias_list = hgnc["Alias symbols"].dropna().tolist()
+    previous_list = hgnc["Previous symbols"].dropna().tolist()
+
+    alias_prev_symbols = alias_list + previous_list
+    alias_prev_symbols = [
+        alias.replace(" ", "") for alias in alias_prev_symbols for alias in alias
+    ]
+
+    found = []
+    for gene in missing:
+        if gene in alias_prev_symbols:
+            try:
+                symbol = hgnc[
+                    hgnc["Alias symbols"].apply(lambda x: query_alias(x, gene))
+                ]["Approved symbol"].values[0]
+            except IndexError:
+                symbol = hgnc[
+                    hgnc["Previous symbols"].apply(lambda x: query_alias(x, gene))
+                ]["Approved symbol"].values[0]
+            # using approved symbol, check refseq genes again
+            # if gene is in refseq, add coordinates to hpo_coord df
+            try:
+                coord = refseq.loc[symbol].copy()
+                hpo_coord = pd.concat([hpo_coord, coord], axis=0)
+                found.append(gene)
+            except KeyError:
+                continue
+
+    missing = [gene for gene in missing if gene not in found]
+    if len(missing) != 0:
+        log_message(f"The following genes could not be found: {missing}")
+        missing_df = pd.DataFrame(missing, columns=["Gene ID"])
+        missing_df.to_csv("genes/missing_genes.txt", sep="\t", index=False)
+
+    # subset columns so dataframe conforms to bed format
+    hpo_coord = hpo_coord[["chromosome", "start", "end"]]
+    hpo_coord = hpo_coord.dropna()
+    hpo_coord.to_csv("genes/temp.bed", sep="\t", index=False, header=False)
+
+    # create bedtools object for merging and sorting
+    bed = pybedtools.BedTool("genes/temp.bed")
+    bed = bed.sort().merge()
+    bed_df = bed.to_dataframe()
+    log_message("Outputting sorted and merged bed file")
+    bed_df.to_csv("genes/genes.bed", sep="\t", header=False, index=False)
+    os.remove("genes/temp.bed")
+
+
+if __name__ == "__main__":
+    hpo = snakemake.input.hpo
+    ensembl = snakemake.input.ensembl
+    refseq = snakemake.input.refseq
+    hgnc = snakemake.input.hgnc
+    main(hpo, ensembl, refseq, hgnc)


### PR DESCRIPTION
This PR adds:

- A script for generating gene coordinates for Ensembl and RefSeq genes (clean_gtf.py, credit to @delvinso who made the original script for STAGER, https://github.com/ccmbioinfo/sampletracker2stager/blob/master/variants/clean_gtf.py)
- A script to generating a bed file corresponding to the genes listed in the HPO files we receive from CHEO (from Phenome Central or G4RD), hpo_to_panel.py. This script queries the genes listed in the HPO file against both the Ensembl and RefSeq gene files to extract coordinates (most genes have Ensembl gene IDs, but not all). It also looks for gene aliases in the HGNC file and then re-queries the RefSeq gene file for genes that are not mapped in the initial step.
- conditional rules for generating the bed file and panel reports if HPO terms are specified in the config.yaml (credit to @aarthi-mohan who started this in the hpo-to-panel branch)
- documentation in the README.md