### PR TITLE
temp fix for bamtofastq rule priority issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Make sure to replace ```~/crg2-conda``` with the path made in step 4. This will 
 - Add the paths to the output files, Homo_sapiens.GRCh37.87.gtf_subset.csv and GRCh37_latest_genomic.gff_subset.csv, to the config["gene"]["ensembl"] and config["gene"]["refseq"] fields.
 - You will also need the HGNC alias file: download this from https://www.genenames.org/download/custom/ using the default fields. Add the path this file to config["gene"]["hgnc"].
 ## Running the pipeline
-1. Make a folder in a directory with sufficient space. Copy over the template files samples.tsv, units.tsv, config.yaml.
+1. Make a folder in a directory with sufficient space. Copy over the template files samples.tsv, units.tsv, config.yaml, pbs_profile/pbs_config.yaml.
 You may need to re-copy config.yaml and pbs_config.yaml if the files were recently updated in repo from previous crg2 runs. Note that 'pbs_config.yaml' is for submitting each rule as cluster jobs, so ignore this if not running on cluster
 ```
 mkdir NA12878
-cp crg2/samples.tsv crg2/units.tsv crg2/config.yaml NA12878 crg2/pbs_profile/pbs_config.yaml
+cp crg2/samples.tsv crg2/units.tsv crg2/config.yaml crg2/pbs_profile/pbs_config.yaml NA12878
 ```
 
-2. Reconfigure the 3 files to reflect project names, sample names, input fastq files, a panel bed file (if any) and a ped file (if any). Inclusion of a panel bed file will generate 2 SNV reports with all variants falling within these regions. Inclusion of a ped file currently does nothing except create a gemini db with the pedigree data stored in it.
+2. Reconfigure the 3 files to reflect project names, sample names, input fastq or bam files, a panel bed file (if any) or hpo file (if any) and a ped file (if any). Inclusion of a panel bed file or hpofile will generate 2 SNV reports with all variants falling within these regions. Inclusion of a ped file with unaffacted parents and an affected proband will allow generation of a de novo report. Note that the default input file type specified in the config is fastq; change this to bam if the inputs are bam files. If there are multiple fastqs per read end, these must be comma-delimited within the units.tsv file. At the moment, the pipeline does not support a mix of fastqs and bam files within a project/family. 
 
 samples.tsv
 ```
@@ -68,8 +68,8 @@ NA12878
 
 units.tsv
 ```
-sample	unit	platform	fq1	fq2
-NA12878	1	ILLUMINA	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_1.fq	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_2.fq
+sample	platform	fq1	fq2
+NA12878	ILLUMINA	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_1.fq	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_2.fq
 ```
 
 config.yaml
@@ -81,6 +81,7 @@ run:
   ped: "" # leave this line blank if there is no ped
   panel: "/hpf/largeprojects/ccmbio/dennis.kao/NA12878/panel.bed" # remove this line entirely if there is no panel bed file
   flank: "100000"
+  input: "fastq" # default fastq; specify bam if input is bam
   
 cre: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre
 
@@ -90,7 +91,7 @@ ref:
 ...
 ```
 
-3. Active the conda environment with Snakemake 5.10.0
+3. Activate the conda environment with Snakemake 5.10.0
 
 ```
 (base) [dennis.kao@qlogin5 crg2]$ conda activate snakemake

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ run:
   panel: "" # three-column BED file based on hpo file; leave this string empty if there is no panel
   hpo: "" # five-column TSV with HPO terms; leave this string empty is there are no hpo terms
   flank: 100000
+  input: "fastq"
 
 genes:
   ensembl: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/Homo_sapiens.GRCh37.87.gtf_subset.csv"

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -1,34 +1,33 @@
-ruleorder: bamtofastq > fastq_prep
 
+if config["run"]["input"] == "fastq":
+    rule fastq_prep:
+        input: 
+            units=config["run"]["units"]
+        output:
+            reads = temp(["fastq/{family}_{sample}_R1.fastq.gz", "fastq/{family}_{sample}_R2.fastq.gz"]) 
+        log:
+            "logs/fastq_prep/{family}_{sample}.log"
+        conda:
+            "../envs/crg.yaml" 
+        script:
+            "../scripts/fastq_prep.py"
+else:
+    rule bamtofastq:
+        input:
+            bam_file = get_bam
+        params:
+            outdir = temp("fastq/"),
+            sort_check = True
+        output:
+            fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
+            fastq2 = temp( "fastq/{family}_{sample}_R2.fastq.gz")
+        log:
+            "logs/bamtofastq/{family}_{sample}.log"
+        threads:
+            4
+        wrapper:
+            get_wrapper_path("bedtools", "bamtofastq")
 
-rule bamtofastq:
-    input:
-        bam_file = get_bam
-    params:
-        outdir = temp("fastq/"),
-        sort_check = True
-    output:
-        fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
-        fastq2 = temp( "fastq/{family}_{sample}_R2.fastq.gz")
-    log:
-        "logs/bamtofastq/{family}_{sample}.log"
-    threads:
-        4
-    wrapper:
-        get_wrapper_path("bedtools", "bamtofastq")
-
-
-rule fastq_prep:
-    input: 
-        units = config["run"]["units"]
-    output:
-        reads = temp(["fastq/{family}_{sample}_R1.fastq.gz", "fastq/{family}_{sample}_R2.fastq.gz"])
-    log:
-         "logs/fastq_prep/{family}_{sample}.log"
-    conda:
-        "../envs/crg.yaml"
-    script:
-        "../scripts/fastq_prep.py"
 
 
 rule map_reads:

--- a/units.tsv
+++ b/units.tsv
@@ -1,2 +1,2 @@
-sample  platform	fq1	fq2	bam
-NA12878 ILLUMINA	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_1.fq	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_2.fq
+sample  platform    fq1 fq2 bam
+NA12878 ILLUMINA    /hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_1.fq	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_2.fq


### PR DESCRIPTION
Previous fix for usage of fastq_prep or bamtofastq rules depending on files specified in units.tsv did not work! The fix in this PR requires that the input type (fastq or bam) be specified in config.yaml. Unfortunately, this means that we cannot support a mix of bams and fastqs at the moment. I tried a few things to dynamically select the rule, but because the input is the same file for both rules (units.tsv), rather than the actual fastq or bam input files, this doesn't seem to work. Will have to return to this in the future. I also updated the README so that it is up to date with recent changes to the pipeline. 