### PR TITLE
HPO annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,3 +241,14 @@ The pipeline generates 6 reports:
 5. EH - a report on repeat expansions in known locations
 
 6. EHDN - a report on denovo repeats filtered from a case-control outlier analysis
+
+## Extra targets
+
+The following targets are not included in the main Snakefile and can be requested in `snakemake` command-line.
+
+1. HPO annotated reports: 
+  Reports from coding, panel and panel-flank can be annotated with HPO terms whenever HPO file is available with us. This is done mainly for monthly GenomeRounds. HPO annotated files are placed in directory: `report/hpo_annotated` using the following command:
+
+  `snakemake --use-conda -s $SF --conda-prefix $CP --profile ${PBS} -p report/hpo_annotated` 
+  The reason to not include this in Snakefile is because there is currently no way to schedule `rule annotate_hpo` after 
+  `rule allsnvreport`. `rule allsnvreport` output is defined as directory, whereas the `rule annotate_hpo` requires actual reports created inside the directory.

--- a/scripts/add_hpo_terms_to_wes.py
+++ b/scripts/add_hpo_terms_to_wes.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+import sys
+from os.path import basename, splitext, join
+
+#Usage: python3 add_hpo_terms_to_wes.py <phenotips_hpo_terms> <wes.report.csv> <outdir>
+
+HPO_DF = pd.read_csv(sys.argv[1], comment='#', skip_blank_lines=True,\
+	sep="\t",  encoding="ISO-8859-1", engine='python').drop(columns=["HPO IDs"])
+
+#Phenotips TSV has a space in column name: " Gene symbol"
+HPO_DF.columns = HPO_DF.columns.str.strip()
+HPO_DF = HPO_DF.rename(columns={'Gene symbol': 'Gene Symbol'})
+
+WES_REPORT = pd.read_csv(sys.argv[2], encoding="ISO-8859-1").set_index("Position")
+
+OUT = join(sys.argv[3],"%s.w_hpoterms.tsv" % splitext(basename(sys.argv[2]))[0])
+
+if "Ensembl_gene_id" in WES_REPORT.columns:
+        HPO_DF = HPO_DF.set_index("Gene ID").drop(columns=["Gene Symbol"])
+        OUT_DF = WES_REPORT.join(HPO_DF, on="Ensembl_gene_id")\
+                .rename(columns={"Number of occurrences": "HPO_count", "Features": "HPO_terms"}).fillna("NA")
+else:
+        HPO_DF = HPO_DF.set_index("Gene Symbol").drop(columns=["Gene ID"])
+       	OUT_DF = WES_REPORT.join(HPO_DF, on="Gene")\
+                .rename(columns={"Number of occurrences": "HPO_count", "Features": "HPO_terms"}).fillna("NA")
+
+OUT_DF.to_csv(OUT, sep="\t", encoding='utf-8')


### PR DESCRIPTION
Once the CSV reports in `report/coding` `report/panel` `report/panel-flank` is available, run the following or edit the `dnaseq_cluster.pbs` file with the target. Annotated reports are stored in `report/hpo_annotated`

`snakemake --use-conda -s $SF --conda-prefix $CP --profile ${PBS} -p report/hpo_annotated`

1.  Properly names  reports inside `report/panel` and `report/panel-flank` with symlink
2. Copied  `add_hpo_terms_to_wes.py` from ~/cre/ -> ~/crg2/scripts and added 3rd argument to pass <output> directory
