### PR TITLE
Bamtofastq bug

### DIFF
--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -19,8 +19,8 @@ else:
             outdir = temp("fastq/"),
             sort_check = True
         output:
-            fastq1 = "fastq/{family}_{sample}_R1.fastq.gz",
-            fastq2 = "fastq/{family}_{sample}_R2.fastq.gz"
+            fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
+            fastq2 = temp( "fastq/{family}_{sample}_R2.fastq.gz")
         log:
             "logs/bamtofastq/{family}_{sample}.log"
         threads:

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -19,8 +19,8 @@ else:
             outdir = temp("fastq/"),
             sort_check = True
         output:
-            fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
-            fastq2 = temp( "fastq/{family}_{sample}_R2.fastq.gz")
+            fastq1 = "fastq/{family}_{sample}_R1.fastq.gz",
+            fastq2 = "fastq/{family}_{sample}_R2.fastq.gz"
         log:
             "logs/bamtofastq/{family}_{sample}.log"
         threads:

--- a/wrappers/bedtools/bamtofastq/wrapper.py
+++ b/wrappers/bedtools/bamtofastq/wrapper.py
@@ -5,6 +5,9 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 sort_cmd = ""
 
+fq1=snakemake.output.fastq1. split(".gz")[0]
+fq2=snakemake.output.fastq2. split(".gz")[0]
+
 bamtofastq_cmd = (
     " bedtools bamtofastq -i {snakemake.input.bam_file} "
     "-fq {snakemake.output.fastq1} "
@@ -27,12 +30,12 @@ if snakemake.params.sort_check:
         )
         bamtofastq_cmd = (
             " bedtools bamtofastq -i /dev/stdin "
-            "-fq {snakemake.output.fastq1} "
-            "-fq2 {snakemake.output.fastq2}; "
+            "-fq {fq1} "
+            "-fq2 {fq2}; "
         )
 
-        fq1_gzip_cmd = " gzip {snakemake.output.fastq1}; "
+        fq1_gzip_cmd = " gzip {fq1}; "
 
-        fq2_gzip_cmd = " gzip {snakemake.output.fastq2}; "
+        fq2_gzip_cmd = " gzip {fq2}; "
 
 shell("(" + sort_cmd + bamtofastq_cmd + fq1_gzip_cmd + fq2_gzip_cmd + ") {log}")

--- a/wrappers/bedtools/bamtofastq/wrapper.py
+++ b/wrappers/bedtools/bamtofastq/wrapper.py
@@ -5,13 +5,13 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 sort_cmd = ""
 
-fq1=snakemake.output.fastq1. split(".gz")[0]
-fq2=snakemake.output.fastq2. split(".gz")[0]
+fq1=snakemake.output.fastq1.split(".gz")[0]
+fq2=snakemake.output.fastq2.split(".gz")[0]
 
 bamtofastq_cmd = (
     " bedtools bamtofastq -i {snakemake.input.bam_file} "
-    "-fq {snakemake.output.fastq1} "
-    "-fq2 {snakemake.output.fastq2}"
+    "-fq {fq1} "
+    "-fq2 {fq2}"
 )
 
 # if bam is not sorted by query name, it must be re-sorted


### PR DESCRIPTION
Fixed the file naming issue in the bamtofastq step that prevented the fastq files from being compressed (which caused downstream issues with the fastqc and fastq screen steps).