### PR TITLE
Increase Java mem to 2g for MarkDuplicates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -98,6 +98,7 @@ params:
     VariantRecalibrator: ""
   picard:
     MarkDuplicates: "REMOVE_DUPLICATES=false"
+    java_opts: "-Xmx2g"
   qualimap:
     mem: "20G"
     nw: 400

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -61,7 +61,8 @@ rule mark_duplicates:
     log:
         "logs/picard/dedup/{family}_{sample}.log"
     params:
-        config["params"]["picard"]["MarkDuplicates"]
+        markDuplicates = config["params"]["picard"]["MarkDuplicates"],
+        java_opts = config["params"]["picard"]["java_opts"],
     wrapper:
         get_wrapper_path("picard", "markduplicates")
 

--- a/wrappers/picard/markduplicates/wrapper.py
+++ b/wrappers/picard/markduplicates/wrapper.py
@@ -8,7 +8,7 @@ from snakemake.shell import shell
 
 
 shell(
-    "picard MarkDuplicates {snakemake.params} INPUT={snakemake.input} "
+    "picard MarkDuplicates {snakemake.params.markDuplicates} {snakemake.params.java_opts}   INPUT={snakemake.input} "
     "OUTPUT={snakemake.output.bam} METRICS_FILE={snakemake.output.metrics} "
     "&> {snakemake.log}"
 )


### PR DESCRIPTION
Ran into error in MarkDuplicates step:
Exception in thread "main" java.lang.OutOfMemoryError: Java heap space
These changes set Java heap space to 2g for the MarkDuplicates step