### PR TITLE
reset variants with platypus set filters, but passing PlatQualDepth to PASS

### DIFF
--- a/wrappers/bcftools/filter/wrapper.py
+++ b/wrappers/bcftools/filter/wrapper.py
@@ -38,6 +38,7 @@ elif soft:
         filter = soft["platypus"]["filter"]
         name = soft["platypus"]["name"]
         command = f"--soft-filter {name} -e '{filter}'  -m + {snakemake.input[0]} "
+        command += f" | bcftools filter --soft-filter PASS -i '{filter}' -m + " 
     elif "gatk" in vcf:
         snvfilter = soft["gatk"]["snvs"]["filter"]
         snvfilter_name = soft["gatk"]["snvs"]["name"]


### PR DESCRIPTION
This fixes #87 

Variant calling with platypus was carried out on sample NA12878. Same recalibrated BAMs were input to the pipeline bcbio and crg2. 
\# variants in platypus VCF (`filtered/HG001-platypus-vt-sf-pass.vcf.g`) from crg2:
before fix: 311392
after fix: 394545

Comparing platypus VCF from crg2 and bcbio: 
|fix|crg2|common|bcbio|
|---|---|---|---|
|before|0|311392 |7534|
|after|76114|318431|~~495~~ 0|

The above 495 are actually duplicate variant records in bcbio VCF, so all 495 variants are already covered under the common variants. 

