### PR TITLE
Allows participant codenames to be integers when creating ped

### DIFF
--- a/rules/common.smk
+++ b/rules/common.smk
@@ -158,6 +158,7 @@ def get_eh_json(wildcards):
 
 def parse_ped_id(individual_id, family):
     if individual_id != "0":
+        individual_id = str(individual_id)
         parsed_id = family + "_" + individual_id.replace(family, "")
     else:
         parsed_id = "0"


### PR DESCRIPTION
Previously, python threw an error if the participant codename was an integer (e.g. 120401). This fix converts the participant codename to a string so that the str.replace() function does not throw an error. 