### PR TITLE
Adding genome-wide CADD scores.

### DIFF
--- a/vcfanno/cre.vcfanno.conf
+++ b/vcfanno/cre.vcfanno.conf
@@ -65,12 +65,19 @@ op="lua:clinvar_sig(clinvar_pathogenic)"
 name="clinvar_sig"
 type="String"
     
+#CADD 1.6 - SNVs
+[[annotation]]
+file = "variation/CADD-1.6_whole_genome_SNVs.tsv.gz"
+names = ["CADD_phred"]
+columns = [6]
+ops = ["concat"]
+
 #dbNSFP v3.4
 [[annotation]]
 file = "variation/dbNSFP.txt.gz"
-names = ["CADD_phred","phyloP20way_mammalian","phastCons20way_mammalian","Vest3_score","Revel_score","Gerp_score"]
-columns = [79,111,115,58,70,107]
-ops = ["first","first","first","first","first","first"]
+names = ["phyloP20way_mammalian","phastCons20way_mammalian","Vest3_score","Revel_score","Gerp_score"]
+columns = [111,115,58,70,107]
+ops = ["first","first","first","first","first"]
 
 # spliceAI
 [[annotation]]

--- a/vcfanno/cre.vcfanno.conf
+++ b/vcfanno/cre.vcfanno.conf
@@ -72,6 +72,13 @@ names = ["CADD_phred"]
 columns = [6]
 ops = ["self"]
 
+#CADD 1.6 - indels
+[[annotation]]
+file = "variation/CADD-1.6_InDels.tsv.gz"
+names = ["CADD_phred"]
+columns = [6]
+ops = ["self"]
+
 #dbNSFP v3.4
 [[annotation]]
 file = "variation/dbNSFP.txt.gz"

--- a/vcfanno/cre.vcfanno.conf
+++ b/vcfanno/cre.vcfanno.conf
@@ -70,7 +70,7 @@ type="String"
 file = "variation/CADD-1.6_whole_genome_SNVs.tsv.gz"
 names = ["CADD_phred"]
 columns = [6]
-ops = ["concat"]
+ops = ["self"]
 
 #dbNSFP v3.4
 [[annotation]]

--- a/vcfanno/crg.vcfanno.conf
+++ b/vcfanno/crg.vcfanno.conf
@@ -65,12 +65,19 @@ op="lua:clinvar_sig(clinvar_pathogenic)"
 name="clinvar_sig"
 type="String"
 
+#CADD 1.6 - SNVs
+[[annotation]]
+file = "CADD-1.6_whole_genome_SNVs.tsv.gz"
+names = ["CADD_phred"]
+columns = [6]
+ops = ["concat"]
+
 #dbNSFP v3.4
 [[annotation]]
 file = "dbNSFP.txt.gz"
-names = ["CADD_phred","phyloP20way_mammalian","phastCons20way_mammalian","Vest3_score","Revel_score","Gerp_score"]
-columns = [79,111,115,58,70,107]
-ops = ["first","first","first","first","first","first"]
+names = ["phyloP20way_mammalian","phastCons20way_mammalian","Vest3_score","Revel_score","Gerp_score"]
+columns = [111,115,58,70,107]
+ops = ["first","first","first","first","first"]
 
 
 # spliceAI

--- a/vcfanno/crg.vcfanno.conf
+++ b/vcfanno/crg.vcfanno.conf
@@ -72,6 +72,13 @@ names = ["CADD_phred"]
 columns = [6]
 ops = ["self"]
 
+#CADD 1.6 - indels
+[[annotation]]
+file = "CADD-1.6_InDels.tsv.gz"
+names = ["CADD_phred"]
+columns = [6]
+ops = ["self"]
+
 #dbNSFP v3.4
 [[annotation]]
 file = "dbNSFP.txt.gz"

--- a/vcfanno/crg.vcfanno.conf
+++ b/vcfanno/crg.vcfanno.conf
@@ -70,7 +70,7 @@ type="String"
 file = "CADD-1.6_whole_genome_SNVs.tsv.gz"
 names = ["CADD_phred"]
 columns = [6]
-ops = ["concat"]
+ops = ["self"]
 
 #dbNSFP v3.4
 [[annotation]]


### PR DESCRIPTION
Downloaded full genome CADD files from [https://cadd.gs.washington.edu/download], specifically **All possible SNVs of GRCh37/hg19** and **48M InDels to initiate a local setup**.
- Removed current CADD annotation from the dbNSFP block in the vcfanno config.
- Added in new CADD annotation blocks to the vcfanno config from the full genome SNV and indel tsv files.