### PR TITLE
VEP config changes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -86,8 +86,6 @@ annotation:
   vep:
     dir: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/6f4af8a1/share/ensembl-vep-104.0-0/"
     dir_cache: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/vep/"
-    maxentscan: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/6f4af8a1/share/ensembl-vep-104.0-0/maxEntScan/"
-    human_ancestor_fasta: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/human_ancestor.fa.gz"
   snpeff:
     dataDir: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/snpeff"
   svscore:

--- a/rules/annotation.smk
+++ b/rules/annotation.smk
@@ -43,8 +43,6 @@ rule vep:
     params:
         dir=config["annotation"]["vep"]["dir"],
         dir_cache=config["annotation"]["vep"]["dir_cache"],
-        maxentscan=config["annotation"]["vep"]["maxentscan"],
-        human_ancestor_fasta=config["annotation"]["vep"]["human_ancestor_fasta"],
         ref=config["ref"]["genome"],
     wrapper:
         get_wrapper_path("vep")

--- a/rules/cre/annotation.smk
+++ b/rules/cre/annotation.smk
@@ -11,8 +11,6 @@ rule vep:
     params:
         dir=config["annotation"]["vep"]["dir"],
         dir_cache=config["annotation"]["vep"]["dir_cache"],
-        maxentscan=config["annotation"]["vep"]["maxentscan"],
-        human_ancestor_fasta=config["annotation"]["vep"]["human_ancestor_fasta"],
         ref=config["ref"]["genome"],
     wrapper:
         get_wrapper_path("vep")

--- a/schemas/config.schema.yaml
+++ b/schemas/config.schema.yaml
@@ -119,15 +119,9 @@ properties:
             type: string
           dir_cache:
             type: string
-          maxentscan:
-            type: string
-          human_ancestor_fasta:
-            type: string
         required:
           - dir
           - dir_cache
-          - maxentscan
-          - human_ancestor_fasta
 
       snpeff:
         type: object

--- a/wrappers/vep/wrapper.py
+++ b/wrappers/vep/wrapper.py
@@ -20,12 +20,6 @@ dirprefix = "--dir {}".format(dir) if dir else ""
 dircache = snakemake.params.get("dir_cache")
 dircacheprefix = "--dir_cache {}".format(dircache) if dircache else ""
 
-maxentscan = snakemake.params.get("maxentscan")
-maxentscanprefix = "--plugin MaxEntScan,{}".format(maxentscan) if maxentscan else ""
-
-humanancestorfasta = snakemake.params.get("human_ancestor_fasta")
-humanancestorfastaprefix = "--plugin LoF,human_ancestor_fa:{},loftee_path:{}".format(humanancestorfasta, dir) if humanancestorfasta and dir else ""
-
 fasta = snakemake.params.get("ref")
 if fasta:
     fastaprefix = "--fasta {}".format(fasta)
@@ -50,7 +44,6 @@ shell(
     "(vep --vcf -o stdout -i {incalls} {threadsprefix} --species homo_sapiens --no_stats --cache --offline {dirprefix} {dircacheprefix} --symbol --numbers --biotype --total_length "
     "--canonical --gene_phenotype --ccds --uniprot --domains --regulatory --protein --tsl --appris --af --max_af --af_1kg --af_esp --af_gnomad "
     "--pubmed --variant_class --allele_number {fastaprefix} "
-    "{humanancestorfastaprefix} {maxentscanprefix} "
     "--plugin SpliceRegion --sift b --polyphen b --hgvs --shift_hgvs 1 --merged  "
     "| sed '/^#/! s/;;/;/g' {outprefix} > {outcalls}) {log}"
 )


### PR DESCRIPTION
Removed maxentscan and human_ancestor_fasta (related to the LOFTEE VEP plugin) from the VEP requirements in the pipeline, as we no longer use either of these tools. Edits made to the:

- VEP rule in both the crg and cre annotations.smk
- VEP wrapper script
- Config schema file 
- Config.yaml template

A [corresponding change](https://github.com/ccmbioinfo/cre/pull/39) will also be made to the cre.vep.sh script in the cre repository, so that this change can also be applied when running the generate_reports.sh script from that repo.