### PR TITLE
Cramtofastq rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mkdir NA12878
 cp crg2/samples.tsv crg2/units.tsv crg2/config.yaml crg2/pbs_profile/pbs_config.yaml NA12878
 ```
 
-2. Reconfigure the 3 files to reflect project names, sample names, input fastq or bam files, a panel bed file (if any) or hpo file (if any) and a ped file (if any). Inclusion of a panel bed file or hpofile will generate 2 SNV reports with all variants falling within these regions. Inclusion of a ped file with unaffacted parents and an affected proband will allow generation of a de novo report. Note that the default input file type specified in the config is fastq; change this to bam if the inputs are bam files. If there are multiple fastqs per read end, these must be comma-delimited within the units.tsv file. At the moment, the pipeline does not support a mix of fastqs and bam files within a project/family. 
+2. Reconfigure the 3 files to reflect project names, sample names, input fastq, bam or cram files, a panel bed file (if any) or hpo file (if any) and a ped file (if any). Inclusion of a panel bed file or hpofile will generate 2 SNV reports with all variants falling within these regions. Inclusion of a ped file with unaffacted parents and an affected proband will allow generation of a de novo report. Note that the default input file type specified in the config is fastq; change this to bam or cram if the inputs are bam or cram files. If you using cram files as input, also make sure that you are specifying the correct cram references - old_cram_ref refers to the original reference the cram was aligned to, and new_cram_ref refers to the new reference used to convert the cram to fastq. You can get the old_cram_ref from the cram file header by running samtools view -H file_name.cram.  If there are multiple fastqs per read end, these must be comma-delimited within the units.tsv file. At the moment, the pipeline does not support a mix of fastqs, bam or cram files within a project/family. 
 
 samples.tsv
 ```
@@ -74,7 +74,7 @@ NA12878
 
 units.tsv
 ```
-sample	platform	fq1	fq2
+sample	platform	fq1	fq2	bam	cram
 NA12878	ILLUMINA	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_1.fq	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_2.fq
 ```
 
@@ -87,7 +87,7 @@ run:
   ped: "" # leave this line blank if there is no ped
   panel: "/hpf/largeprojects/ccmbio/dennis.kao/NA12878/panel.bed" # remove this line entirely if there is no panel bed file
   flank: "100000"
-  input: "fastq" # default fastq; specify bam if input is bam
+  input: "fastq" # default fastq; specify bam if input is bam or cram
   
 cre: /hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre
 

--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,8 @@ ref:
   canon_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/grch37.canon.bed"
   split_genome: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/split_genome"
   gatk-known: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/Mills_and_1000G_gold_standard.indels.vcf.gz"
+  old_cram_ref: "UR:/mnt/hnas/reference/hg19/hg19.fa"
+  new_cram_ref: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/hg19/seq/hg19.fa"
 
 filtering:
   vqsr: false

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -37,6 +37,7 @@ elif config["run"]["input"] == "cram":
         output:
             fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
             fastq2 = temp("fastq/{family}_{sample}_R2.fastq.gz")
+        shadow: "shallow"
         log:
             "logs/cramtofastq/{family}_{sample}.log"
         wrapper:

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -32,8 +32,8 @@ elif config["run"]["input"] == "cram":
         input:
             units=config["run"]["units"]
         params:
-            OldCramRef = config["ref"]["old_cram_ref"],
-            NewCramRef = config["ref"]["new_cram_ref"]
+            old_cram_ref = config["ref"]["old_cram_ref"],
+            new_cram_ref = config["ref"]["new_cram_ref"]
         output:
             fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
             fastq2 = temp("fastq/{family}_{sample}_R2.fastq.gz")

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -11,7 +11,7 @@ if config["run"]["input"] == "fastq":
             "../envs/crg.yaml" 
         script:
             "../scripts/fastq_prep.py"
-else:
+elif config["run"]["input"] == "bam":
     rule bamtofastq:
         input:
             bam_file = get_bam
@@ -27,7 +27,20 @@ else:
             4
         wrapper:
             get_wrapper_path("bedtools", "bamtofastq")
-
+elif config["run"]["input"] == "cram":
+    rule cramtofastq:
+        input:
+            units=config["run"]["units"]
+        params:
+            OldCramRef = config["ref"]["old_cram_ref"],
+            NewCramRef = config["ref"]["new_cram_ref"]
+        output:
+            fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
+            fastq2 = temp("fastq/{family}_{sample}_R2.fastq.gz")
+        log:
+            "logs/cramtofastq/{family}_{sample}.log"
+        wrapper:
+            get_wrapper_path("samtools", "fastq")
 
 
 rule map_reads:

--- a/schemas/config.schema.yaml
+++ b/schemas/config.schema.yaml
@@ -59,6 +59,10 @@ properties:
         type: string
       canon_bed:
         type: string
+      old_cram_ref:
+        type: string
+      new_cram_ref:
+        type: string
     required:
       - genome
       - known-variants

--- a/schemas/units.schema.yaml
+++ b/schemas/units.schema.yaml
@@ -17,6 +17,9 @@ properties:
   bam:
     type: string
     description: path to bam file (fill this in if fastqs are not available)
+  cram:
+    type: string
+    description: path to cram file (if available)
 required:
   - sample
   - platform

--- a/units.tsv
+++ b/units.tsv
@@ -1,2 +1,2 @@
-sample	platform	fq1	fq2	bam
-NA12878	ILLUMINA	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_1.fq.gz	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_2.fq.gz	
+sample	platform	fq1	fq2	bam	cram
+NA12878	ILLUMINA	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_1.fq.gz	/hpf/largeprojects/ccm_dccforge/dccdipg/Common/NA12878/NA12878.bam_2.fq.gz		

--- a/wrappers/samtools/fastq/environment.yaml
+++ b/wrappers/samtools/fastq/environment.yaml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - samtools ==1.10

--- a/wrappers/samtools/fastq/wrapper.py
+++ b/wrappers/samtools/fastq/wrapper.py
@@ -18,11 +18,14 @@ copy_cmd = (" cp {cram_file} {dest}; ")
 
 get_header_cmd = (" samtools view -H {dest} > fastq/{family}_{sample}_header.sam; ")
 
-sed_cmd = (" sed -i 's+{snakemake.params.OldCramRef}+UR:{snakemake.params.NewCramRef}+g' fastq/{family}_{sample}_header.sam; ")
+sed_cmd = (" sed -i 's+{snakemake.params.old_cram_ref}+UR:{snakemake.params.new_cram_ref}+g' fastq/{family}_{sample}_header.sam; ")
 
 reheader_cmd = (" samtools reheader -i fastq/{family}_{sample}_header.sam {dest}; ")
 
-fastq_cmd = (" samtools sort -n {dest} | samtools fastq - --reference {snakemake.params.NewCramRef} -1 fastq/{family}_{sample}_R1.fastq.gz -2 fastq/{family}_{sample}_R2.fastq.gz -s fastq/{family}_{sample}_singleton.fastq.gz; ")
+fastq_cmd = (" samtools sort -n {dest} | samtools fastq - --reference {snakemake.params.new_cram_ref} "
+" -1 fastq/{family}_{sample}_R1.fastq.gz"
+" -2 fastq/{family}_{sample}_R2.fastq.gz"
+" -s fastq/{family}_{sample}_singleton.fastq.gz; ")
 
 rm_cmd = (" rm -f fastq/{family}_{sample}_header.sam fastq/{family}_{sample}.cram fastq/{family}_{sample}_singleton.fastq.gz; ")
 

--- a/wrappers/samtools/fastq/wrapper.py
+++ b/wrappers/samtools/fastq/wrapper.py
@@ -24,4 +24,6 @@ reheader_cmd = (" samtools reheader -i fastq/{family}_{sample}_header.sam {dest}
 
 fastq_cmd = (" samtools sort -n {dest} | samtools fastq - --reference {snakemake.params.NewCramRef} -1 fastq/{family}_{sample}_R1.fastq.gz -2 fastq/{family}_{sample}_R2.fastq.gz -s fastq/{family}_{sample}_singleton.fastq.gz; ")
 
-shell("(" + copy_cmd + get_header_cmd + sed_cmd + reheader_cmd + fastq_cmd + ") {log}")
+rm_cmd = (" rm -f fastq/{family}_{sample}_header.sam fastq/{family}_{sample}.cram fastq/{family}_{sample}_singleton.fastq.gz; ")
+
+shell("(" + copy_cmd + get_header_cmd + sed_cmd + reheader_cmd + fastq_cmd + rm_cmd + ") {log}")

--- a/wrappers/samtools/fastq/wrapper.py
+++ b/wrappers/samtools/fastq/wrapper.py
@@ -1,0 +1,27 @@
+from snakemake.shell import shell
+import os
+import pandas as pd
+
+log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+
+family = snakemake.wildcards.family
+sample = snakemake.wildcards.sample
+
+name = f"{snakemake.wildcards.family}_{snakemake.wildcards.sample}"
+
+units = pd.read_table(snakemake.input.units, dtype=str).set_index(["sample"], drop=False)
+cram_file = units.loc[sample, 'cram']
+
+dest = os.path.join(f"fastq/{family}_{sample}.cram")
+
+copy_cmd = (" cp {cram_file} {dest}; ")
+
+get_header_cmd = (" samtools view -H {dest} > fastq/{family}_{sample}_header.sam; ")
+
+sed_cmd = (" sed -i 's+{snakemake.params.OldCramRef}+UR:{snakemake.params.NewCramRef}+g' fastq/{family}_{sample}_header.sam; ")
+
+reheader_cmd = (" samtools reheader -i fastq/{family}_{sample}_header.sam {dest}; ")
+
+fastq_cmd = (" samtools sort -n {dest} | samtools fastq - --reference {snakemake.params.NewCramRef} -1 fastq/{family}_{sample}_R1.fastq.gz -2 fastq/{family}_{sample}_R2.fastq.gz -s fastq/{family}_{sample}_singleton.fastq.gz; ")
+
+shell("(" + copy_cmd + get_header_cmd + sed_cmd + reheader_cmd + fastq_cmd + ") {log}")


### PR DESCRIPTION
Added a cramtofastq rule + wrapper, using samtools fastq, based on [this script](https://github.com/ccmbioinfo/cre/blob/master/cram2fastq_samtools.pbs). Also made changes to the config and schema so that it is possible to change the paths to both the old and new references in the config.yaml. 

So overall usage of this rule: 
(1) Put path to cram file in the units.tsv.
(2) Set input in config.yaml to "cram".
(3) Change the old/new cram references in the config.yaml, or use the default ones.

Note: The samtools fastq step produces temporary bam files in the central project directory while it runs, making it look a bit clunky. These are removed at the end of the step, so not sure if this is a big concern that we need to address.