### PR TITLE
Multiqc

### DIFF
--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -3,7 +3,8 @@ rule fastqc:
         reads=["fastq/{family}_{sample}_R1.fastq.gz", "fastq/{family}_{sample}_R2.fastq.gz"]
     output:
         html="qc/fastqc/{family}_{sample}.html",
-        zip="qc/fastqc/{family}_{sample}.zip"
+        zip="qc/fastqc/{family}_{sample}.zip",
+        unzip_folder=directory("qc/fastqc/{family}_{sample}")
     log:
         "logs/fastqc/{family}_{sample}.log"
     wrapper:
@@ -80,8 +81,7 @@ rule verifybamid2:
 rule multiqc:
     input:
         [expand(input_file, sample=samples.index,family=project) for input_file in ["qc/samtools-stats/{family}_{sample}.txt", 
-                                                            "qc/fastqc/{family}_{sample}.zip",
-                                                            "qc/fastqc/{family}_{sample}.zip", 
+                                                            "qc/fastqc/{family}_{sample}", 
                                                             "qc/dedup/{family}_{sample}.metrics.txt", 
                                                             "qc/verifybamid2/{family}_{sample}.selfSM", 
                                                             "qc/qualimap/{family}_{sample}/genome_results.txt", 

--- a/wrappers/fastqc/wrapper.py
+++ b/wrappers/fastqc/wrapper.py
@@ -39,17 +39,7 @@ with TemporaryDirectory() as tempdir:
     html_path = path.join(tempdir, output_base + "_fastqc.html")
     zip_path = path.join(tempdir, output_base + "_fastqc.zip")
  
-
-    #shell(
-        #" unzip -o {zip_path} -d {tempdir}"
-    #)
-    #unzip_path = path.join(tempdir, output_base + "_fastqc")
-    #unzip_path_rename = path.join(tempdir, output_base)
-    #shell("mv {unzip_path} {unzip_path_rename}")
-
-    #unzip_folder = path.join(tempdir, output_base)
-    #unzip_base = "_".join(output_base.split("_")[:-1])
-    
+   
     if snakemake.output.html != html_path:
         shell("mv {html_path} {snakemake.output.html}")
 

--- a/wrappers/fastqc/wrapper.py
+++ b/wrappers/fastqc/wrapper.py
@@ -38,9 +38,33 @@ with TemporaryDirectory() as tempdir:
     output_base = basename_without_ext(snakemake.input[0])
     html_path = path.join(tempdir, output_base + "_fastqc.html")
     zip_path = path.join(tempdir, output_base + "_fastqc.zip")
+ 
 
+    #shell(
+        #" unzip -o {zip_path} -d {tempdir}"
+    #)
+    #unzip_path = path.join(tempdir, output_base + "_fastqc")
+    #unzip_path_rename = path.join(tempdir, output_base)
+    #shell("mv {unzip_path} {unzip_path_rename}")
+
+    #unzip_folder = path.join(tempdir, output_base)
+    #unzip_base = "_".join(output_base.split("_")[:-1])
+    
     if snakemake.output.html != html_path:
         shell("mv {html_path} {snakemake.output.html}")
 
     if snakemake.output.zip != zip_path:
         shell("mv {zip_path} {snakemake.output.zip}")
+
+    shell(
+        " unzip -o {snakemake.output.zip} -d qc/fastqc "
+    )
+
+    #rename in qc/fastqc
+    unzip_folder = path.join("qc/fastqc", output_base + "_fastqc")
+    shell(" mv {unzip_folder} {snakemake.output.unzip_folder}")
+
+    unzip_base = "_".join(output_base.split("_")[:-1])
+    fastqc_report_path = path.join(snakemake.output.unzip_folder, "fastqc_data.txt")
+    shell("sed -i 's/{output_base}.fastq.gz/{unzip_base}.fastq.gz/g' {fastqc_report_path}")
+


### PR DESCRIPTION
The fastqc metrics were not in multiqc report due to some improper namings. Multiqc recognizes "\_fastqc.zip" or the unzipped folder only. I unzipped the zipped folder first. To prevent multiqc from recognizing  {family}\_{sample}\_R1 as an additional sample, I renamed the sample from {family}\_{sample}\_R1 to {family}\_{sample}. 