### PR TITLE
add --DisableSanityCheck to verifybamID2

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -143,7 +143,8 @@ params:
     extra: ""
   verifybamid2:
     svd_prefix: "1000g.phase3 100k b37"
-    extra: ""
+    # --DisableSanityCheck ensures verifybamid2 does not fail for exomes with < 10,000 markers
+    extra: "--DisableSanityCheck"
   snpeff:
     java_opts: "-Xms750m -Xmx20g"
   svscore:


### PR DESCRIPTION
Add --DisableSanityCheck flag to verifybamID2 command so that verifybamID2 doesn't fail if there are fewer than 10,000 SNP markers. This is relevant for exomes, which sometimes fall just short of 10K markers. 
https://groups.google.com/g/verifybamid/c/KtnfvkeauXk?pli=1