### PR TITLE
Exome parser fix for fastq-input exomes

### DIFF
--- a/parser_exomes.py
+++ b/parser_exomes.py
@@ -24,8 +24,8 @@ crg2_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
 def input_file(input_path):
     """Given hpf path, find input files"""
-    fq1 = glob.glob(os.path.join(input_path, "*R1_*fastq.gz"))
-    fq2 = glob.glob(os.path.join(input_path, "*R2_*fastq.gz"))
+    fq1 = sorted(glob.glob(os.path.join(input_path, "*R1_*fastq.gz")))
+    fq2 = sorted(glob.glob(os.path.join(input_path, "*R2_*fastq.gz")))
     bam = glob.glob(os.path.join(input_path, "*bam"))
     cram = glob.glob(os.path.join(input_path, "*cram"))
     # prioritize fastq as input, then bam, then cram


### PR DESCRIPTION
Some fastq-input exomes fail at the BWA mapping step because of a "paired reads have different names" bwa-mem error. This is because the R1 and R2 fastq files get concatenated in different orders. I have added a sorted() function to the parser script to order the fastq files in the directory first and prevent this from happening. 