### PR TITLE
Slurm profile and exome analysis set up script for integration with Stager

### DIFF
--- a/dnaseq_slurm.sh
+++ b/dnaseq_slurm.sh
@@ -9,7 +9,7 @@ SF=~/crg2/Snakefile
 CP="/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake"
 SLURM=~/crg2/slurm_profile
 
-source /storage/modules/anaconda/2020.11/etc/profile.d/conda.sh
+source /hpf/largeprojects/ccm_dccforge/dccdipg/Common/anaconda3/etc/profile.d/conda.sh
 conda activate snakemake_5.10.0 
 
 snakemake --use-conda -s ${SF} --cores 4 --conda-prefix ${CP} --profile $SLURM  

--- a/dnaseq_slurm.sh
+++ b/dnaseq_slurm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --job-name=crg2
+#SBATCH --time=50:00:00
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=4G
+#SBATCH --output=%x-%j.out
+
+SF=~/crg2/Snakefile
+CP="/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake"
+SLURM=~/crg2/slurm_profile
+
+source /storage/modules/anaconda/2020.11/etc/profile.d/conda.sh
+conda activate snakemake_5.10.0 
+
+snakemake --use-conda -s ${SF} --cores 4 --conda-prefix ${CP} --profile $SLURM  

--- a/dnaseq_slurm_api.sh
+++ b/dnaseq_slurm_api.sh
@@ -1,0 +1,32 @@
+# sample commands to be called by stager slurm.py with variable substitution
+# assumes crg2 is installed in home directory of user
+# in production, crg2 is located in /home/ccmmarvin
+SF=~/crg2/Snakefile; 
+CP="/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake";
+SLURM=~/crg2/slurm_profile;
+
+source /hpf/largeprojects/ccm_dccforge/dccdipg/Common/anaconda3/etc/profile.d/conda.sh
+conda activate snakemake
+
+if [ ! -d {filepath}/{family} ];then
+    mkdir {filepath}/{family}
+else
+    echo "Analysis directory {filepath}/{family} exists, exiting"
+    exit
+
+
+mkdir {filepath}/{family}
+cd {filepath}/{family}
+
+python3 exome_setup.py \
+    -a {filepath}/{family} \
+    -f {family} \
+    -d {participant}:{linked_files} {participant}:{linked_files} {participant}:{linked_files}
+
+exit_code=`echo $?`
+if [ $exit_code == 0 ]; then
+    snakemake --use-conda -s $SF --conda-prefix $CP  --profile $SLURM -p 
+else
+    echo 'Analysis setup failed, exiting'
+    exit
+

--- a/exome_setup_stager.py
+++ b/exome_setup_stager.py
@@ -1,0 +1,187 @@
+import argparse
+import ast
+import logging
+import os
+import shutil
+import sys
+
+# replace with /home/ccmmarvin/crg2 when in production
+crg2_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+
+
+def replace_str(filename, target, replacement):
+    # pythonized sed
+    with open(filename, "r") as file:
+        lines = file.readlines()
+    with open(filename, "w") as file:
+        for line in lines:
+            line = line.replace(target, replacement)
+            file.write(line)
+
+
+def setup_directory(filepath):
+    # copy config.yaml, pbs_config.yaml, and dnaseq_cluster.pbs
+    for i in ["config.yaml", "pbs_profile/pbs_config.yaml", "dnaseq_cluster.pbs"]:
+        src = os.path.join(crg2_dir, i)
+        if i == "pbs_profile/pbs_config.yaml":
+            dest = os.path.join(filepath, "pbs_config.yaml")
+        else:
+            dest = os.path.join(filepath, i)
+        shutil.copyfile(src, dest)
+
+
+def write_config(family, input_type_list, filepath):
+    # replace family ID in config.yaml & dnaseq_cluster.pbs
+    config = os.path.join(filepath, "config.yaml")
+    replace_str(config, "NA12878", family)
+
+    # modify input type depending on input file
+    input_set = set(input_type_list)
+    if input_set == {"bam"}:
+        replace_str(config, 'input: "fastq"', 'input: "bam"')
+    elif input_set == {"cram"}:
+        replace_str(config, 'input: "fastq"', 'input: "cram"')
+    elif input_set != {"fastq"}:
+        logging.error("Mixed input filetypes among participants detected, exiting")
+        sys.exit(1)
+
+
+def input_type(file, participant):
+    # determine filetype of linked file based on file suffix
+    if file.endswith("fastq.gz") or file.endswith("fq.gz"):
+        if "R1" in file:
+            filetype = "fq1"
+        elif "R2" in file:
+            filetype = "fq2"
+        else:
+            logging.error(
+                "Unrecognized fastq file format for %s, exiting" % participant
+            )
+            sys.exit(1)
+    elif file.endswith("bam"):
+        filetype = "bam"
+    elif file.endswith("cram"):
+        filetype = "cram"
+    else:
+        filetype = None
+    return filetype
+
+
+def dataset_to_dict(datasets):
+    # create dict of dicts with participant/sample name and associated files
+    all_datasets_dict = {}
+    for dataset in datasets:
+        participant = ast.literal_eval(dataset.split(":")[0])
+        files = ast.literal_eval(dataset.split(":")[1])
+        keys = ["fq1", "fq2", "bam", "cram"]
+        dataset_dict = {k: [] for k in keys}
+        all_datasets_dict[participant] = dataset_dict
+        for f in files:
+            filetype = input_type(f, participant)
+            if filetype == "bam":
+                all_datasets_dict[participant]["bam"].append(f)
+            elif filetype == "cram":
+                all_datasets_dict[participant]["cram"].append(f)
+            elif filetype == "fq1":
+                all_datasets_dict[participant]["fq1"].append(f)
+            elif filetype == "fq2":
+                all_datasets_dict[participant]["fq2"].append(f)
+    return all_datasets_dict
+
+
+def write_units_samples(datasets_dict, filepath):
+    units, samples = os.path.join(filepath, "units.tsv"), os.path.join(
+        filepath, "samples.tsv"
+    )
+    input_type_list = []
+    with open(units, "w") as u, open(samples, "w") as s:
+        s.writelines("sample\n")
+        u.writelines("sample\tplatform\tfq1\tfq2\tbam\tcram\n")
+        for participant in datasets_dict:
+            s.writelines(f"{participant}\n")
+            bam = datasets_dict[participant]["bam"]
+            cram = datasets_dict[participant]["cram"]
+            fq1 = datasets_dict[participant]["fq1"]
+            fq2 = datasets_dict[participant]["fq2"]
+            # if fastqs available, set these as input files
+            if len(fq1) != 0:
+                fq1 = ",".join(fq1)
+                fq2 = ",".join(fq2)
+                u.writelines(f"{participant}\tILLUMINA\t{fq1}\t{fq2}\t\t\n")
+                input_type_list.append("fastq")
+            # if bam available, set as input file
+            elif len(bam) != 0:
+                if len(bam) == 1:
+                    u.writelines(f"{participant}\tILLUMINA\t\t\t{bam[0]}\t\n")
+                    input_type_list.append("bam")
+                else:
+                    logging.error(
+                        "Multiple bam files provided for %s, exiting" % participant
+                    )
+                    sys.exit(1)
+            # if cram available, set as input file
+            elif len(cram) != 0:
+                if len(cram) == 1:
+                    u.writelines(f"{participant}\tILLUMINA\t\t\t{cram[0]}\t\n")
+                    input_type_list.append("cram")
+                else:
+                    logging.error("Multiple cram files provided, exiting")
+                    sys.exit(1)
+            else:
+                logging.error("No input file provided for %s, exiting" % participant)
+                sys.exit(1)
+    return input_type_list
+
+
+if __name__ == "__main__":
+    description = "Sets up crg2 exome pipeline run from Stager analysis metadata"
+    parser = argparse.ArgumentParser(description=description)
+    # set up directory:
+    # copy config files etc
+    # based on family, pipeline and input type, modify config.yaml
+    # create units.tsv and samples.tsv based on input
+    parser.add_argument(
+        "-f",
+        "--family",
+        type=str,
+        required=True,
+        help="Family codename",
+    )
+
+    parser.add_argument(
+        "-d",
+        "--datasets",
+        type=str,
+        nargs="+",
+        required=True,
+        help="List of participants and their associated files in the format participant_codename:linked_file(s)",
+    )
+
+    parser.add_argument(
+        "-a",
+        "--analysis_directory",
+        type=str,
+        required=True,
+        help="Base path for in which analyses are run",
+    )
+
+    args = parser.parse_args()
+    family = args.family
+    datasets = args.datasets
+    filepath = os.path.join(args.analysis_directory, family)
+
+    logging.basicConfig(
+        filename="%s/setup.log" % filepath,
+        level=logging.INFO,
+        format="%(asctime)s %(message)s",
+    )
+
+    logging.info("Setting up directory for crg2 run")
+    setup_directory(filepath)
+    logging.info("Parsing participants' linked files")
+    datasets_dict = dataset_to_dict(datasets)
+    logging.info("Writing units.tsv and samples.tsv files")
+    input_type_list = write_units_samples(datasets_dict, filepath)
+    logging.info("Parsing config.yaml")
+    write_config(family, input_type_list, filepath)
+    logging.info("crg2 set up complete")

--- a/slurm_profile/CookieCutter.py
+++ b/slurm_profile/CookieCutter.py
@@ -1,0 +1,31 @@
+#
+# Based on lsf CookieCutter.py
+#
+import os
+import json
+
+d = os.path.dirname(__file__)
+with open(os.path.join(d, "settings.json")) as fh:
+    settings = json.load(fh)
+
+
+class CookieCutter:
+
+    SBATCH_DEFAULTS = settings['SBATCH_DEFAULTS']
+    CLUSTER_NAME = settings['CLUSTER_NAME']
+    CLUSTER_CONFIG = settings['CLUSTER_CONFIG']
+    ADVANCED_ARGUMENT_CONVERSION = settings['ADVANCED_ARGUMENT_CONVERSION']
+
+    @staticmethod
+    def get_cluster_option() -> str:
+        cluster = CookieCutter.CLUSTER_NAME
+        if cluster != "":
+            return f"--cluster={cluster}"
+        return ""
+
+    @staticmethod
+    def get_advanced_argument_conversion() -> bool:
+        val = {"yes": True, "no": False}[
+            CookieCutter.ADVANCED_ARGUMENT_CONVERSION
+        ]
+        return val

--- a/slurm_profile/config.yaml
+++ b/slurm_profile/config.yaml
@@ -1,0 +1,17 @@
+restart-times: 1
+jobscript: "slurm-jobscript.sh"
+cluster: "slurm-submit.py"
+cluster-status: "slurm-status.py"
+cluster-config: "slurm-config.yaml"
+max-jobs-per-second: 1
+max-status-checks-per-second: 1
+cores: 64
+local-cores: 1
+resources: [cpus=64]
+rerun-incomplete: true  # recommended for cluster submissions
+keep-going: false
+notemp: false
+immediate-submit: false
+latency-wait: 60
+verbose: true
+printshellcmds: true

--- a/slurm_profile/settings.json
+++ b/slurm_profile/settings.json
@@ -1,0 +1,6 @@
+{
+    "SBATCH_DEFAULTS": "",
+    "CLUSTER_NAME": "",
+    "CLUSTER_CONFIG": "slurm-config.yaml",
+    "ADVANCED_ARGUMENT_CONVERSION": "no"
+}

--- a/slurm_profile/slurm-config.yaml
+++ b/slurm_profile/slurm-config.yaml
@@ -1,0 +1,52 @@
+## the following <option>:<value> are defined in key_mapping.yaml file
+## this file sets the rule specific values for the option
+## options set here are available under dict "job_properties["cluster"]" from within snakemake
+## these options are handled in the pbs_submit.py script
+##
+## if you wish to add new <option>:<value>, you should
+##  1. define the option and format string "{}" acceptable to the submission(qsub) command in key_mapping.yaml
+##  2. set the value for the option in this file under __default__ or rule specific block
+##  3. if needed, edit "pbs_submit.py" to handle the new options. By default, all options defined in 
+##    "key_mapping.yaml" are updated with values from this config file and are appended to the submission command. 
+##
+## option: value -> equivalent qsub parameter it sets
+## name: "{rule}" -> -N {rule}
+## mem: "20g" -> -l vmem=20g,mem=20g
+## time: "15:00:00" -> -l walltime: 15:00:00
+## mail: "ae" -> -m ae
+## queue: "parallel" -> -q parallel
+## threads: 7 -> -l nodes=1,ppn=7
+
+__default__:
+  job-name: "{rule}"
+  mem: "20G"
+  time: "20:00:00"
+  output: "slurm/%x-%j.out"
+
+map_reads:
+  time: "350:00:00"
+
+snpeff:
+  mem: "25G"
+
+qualimap:
+  mem: "30G"
+
+allsnvreport:
+  mem: "60G"
+
+wham:
+  mem: "100G"
+
+smoove:
+  mem: "100G"
+
+manta:
+  mem: "100G"
+
+
+
+
+
+
+

--- a/slurm_profile/slurm-jobscript.sh
+++ b/slurm_profile/slurm-jobscript.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# properties = {properties}
+{exec_job}

--- a/slurm_profile/slurm-status.py
+++ b/slurm_profile/slurm-status.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import re
+import subprocess as sp
+import shlex
+import sys
+import time
+import logging
+from CookieCutter import CookieCutter
+
+logger = logging.getLogger("__name__")
+
+STATUS_ATTEMPTS = 20
+
+jobid = sys.argv[1]
+
+cluster = CookieCutter.get_cluster_option()
+
+for i in range(STATUS_ATTEMPTS):
+    try:
+        sacct_res = sp.check_output(shlex.split(f"sacct {cluster} -P -b -j {jobid} -n"))
+        res = {
+            x.split("|")[0]: x.split("|")[1]
+            for x in sacct_res.decode().strip().split("\n")
+        }
+        break
+    except sp.CalledProcessError as e:
+        logger.error("sacct process error")
+        logger.error(e)
+    except IndexError as e:
+        logger.error(e)
+        pass
+    # Try getting job with scontrol instead in case sacct is misconfigured
+    try:
+        sctrl_res = sp.check_output(
+            shlex.split(f"scontrol {cluster} -o show job {jobid}")
+        )
+        m = re.search(r"JobState=(\w+)", sctrl_res.decode())
+        res = {jobid: m.group(1)}
+        break
+    except sp.CalledProcessError as e:
+        logger.error("scontrol process error")
+        logger.error(e)
+        if i >= STATUS_ATTEMPTS - 1:
+            print("failed")
+            exit(0)
+        else:
+            time.sleep(1)
+
+status = res[jobid]
+
+if status == "BOOT_FAIL":
+    print("failed")
+elif status == "OUT_OF_MEMORY":
+    print("failed")
+elif status.startswith("CANCELLED"):
+    print("failed")
+elif status == "COMPLETED":
+    print("success")
+elif status == "DEADLINE":
+    print("failed")
+elif status == "FAILED":
+    print("failed")
+elif status == "NODE_FAIL":
+    print("failed")
+elif status == "PREEMPTED":
+    print("failed")
+elif status == "TIMEOUT":
+    print("failed")
+# Unclear whether SUSPENDED should be treated as running or failed
+elif status == "SUSPENDED":
+    print("failed")
+else:
+    print("running")

--- a/slurm_profile/slurm-submit.py
+++ b/slurm_profile/slurm-submit.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Snakemake SLURM submit script.
+"""
+from snakemake.utils import read_job_properties
+
+import slurm_utils
+from CookieCutter import CookieCutter
+
+# cookiecutter arguments
+SBATCH_DEFAULTS = CookieCutter.SBATCH_DEFAULTS
+CLUSTER = CookieCutter.get_cluster_option()
+CLUSTER_CONFIG = CookieCutter.CLUSTER_CONFIG
+ADVANCED_ARGUMENT_CONVERSION = CookieCutter.get_advanced_argument_conversion()
+
+RESOURCE_MAPPING = {
+    "time": ("time", "runtime", "walltime"),
+    "mem": ("mem", "mem_mb", "ram", "memory"),
+    "mem-per-cpu": ("mem-per-cpu", "mem_per_cpu", "mem_per_thread"),
+    "nodes": ("nodes", "nnodes"),
+}
+
+# parse job
+jobscript = slurm_utils.parse_jobscript()
+job_properties = read_job_properties(jobscript)
+
+sbatch_options = {}
+cluster_config = slurm_utils.load_cluster_config(CLUSTER_CONFIG)
+
+# 1) sbatch default arguments and cluster
+sbatch_options.update(slurm_utils.parse_sbatch_defaults(SBATCH_DEFAULTS))
+sbatch_options.update(slurm_utils.parse_sbatch_defaults(CLUSTER))
+
+# 2) cluster_config defaults
+sbatch_options.update(cluster_config["__default__"])
+
+# 3) Convert resources (no unit conversion!) and threads
+sbatch_options.update(
+    slurm_utils.convert_job_properties(job_properties, RESOURCE_MAPPING)
+)
+
+# 4) cluster_config for particular rule
+sbatch_options.update(cluster_config.get(job_properties.get("rule"), {}))
+
+# 5) cluster_config options
+sbatch_options.update(job_properties.get("cluster", {}))
+
+# 6) Advanced conversion of parameters
+if ADVANCED_ARGUMENT_CONVERSION:
+    sbatch_options = slurm_utils.advanced_argument_conversion(sbatch_options)
+
+# 7) Format pattern in snakemake style
+sbatch_options = slurm_utils.format_values(sbatch_options, job_properties)
+
+# ensure sbatch output dirs exist
+for o in ("output", "error"):
+    slurm_utils.ensure_dirs_exist(sbatch_options[o]) if o in sbatch_options else None
+
+# submit job and echo id back to Snakemake (must be the only stdout)
+print(slurm_utils.submit_job(jobscript, **sbatch_options))

--- a/slurm_profile/slurm_utils.py
+++ b/slurm_profile/slurm_utils.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+import os
+import sys
+from os.path import dirname
+import re
+import math
+import argparse
+import subprocess as sp
+from io import StringIO
+
+from snakemake import io
+from snakemake.io import Wildcards
+from snakemake.utils import SequenceFormatter
+from snakemake.utils import AlwaysQuotedFormatter
+from snakemake.utils import QuotedFormatter
+from snakemake.exceptions import WorkflowError
+from snakemake.logging import logger
+
+from CookieCutter import CookieCutter
+
+
+def _convert_units_to_mb(memory):
+    """If memory is specified with SI unit, convert to MB"""
+    if isinstance(memory, int) or isinstance(memory, float):
+        return int(memory)
+    siunits = {"K": 1e-3, "M": 1, "G": 1e3, "T": 1e6}
+    regex = re.compile(r"(\d+)({})$".format("|".join(siunits.keys())))
+    m = regex.match(memory)
+    if m is None:
+        logger.error(
+            (
+                f"unsupported memory specification '{memory}';"
+                "  allowed suffixes: [K|M|G|T]"
+            )
+        )
+        sys.exit(1)
+    factor = siunits[m.group(2)]
+    return int(int(m.group(1)) * factor)
+
+
+def parse_jobscript():
+    """Minimal CLI to require/only accept single positional argument."""
+    p = argparse.ArgumentParser(description="SLURM snakemake submit script")
+    p.add_argument("jobscript", help="Snakemake jobscript with job properties.")
+    return p.parse_args().jobscript
+
+
+def parse_sbatch_defaults(parsed):
+    """Unpack SBATCH_DEFAULTS."""
+    d = parsed.split() if type(parsed) == str else parsed
+    args = {}
+    for keyval in [a.split("=") for a in d]:
+        k = keyval[0].strip().strip("-")
+        v = keyval[1].strip() if len(keyval) == 2 else None
+        args[k] = v
+    return args
+
+
+def load_cluster_config(path):
+    """Load config to dict
+
+    Load configuration to dict either from absolute path or relative
+    to profile dir.
+    """
+    if path:
+        path = os.path.join(dirname(__file__), os.path.expandvars(path))
+        dcc = io.load_configfile(path)
+    else:
+        dcc = {}
+    if "__default__" not in dcc:
+        dcc["__default__"] = {}
+    return dcc
+
+
+# adapted from format function in snakemake.utils
+def format(_pattern, _quote_all=False, **kwargs):  # noqa: A001
+    """Format a pattern in Snakemake style.
+    This means that keywords embedded in braces are replaced by any variable
+    values that are available in the current namespace.
+    """
+    fmt = SequenceFormatter(separator=" ")
+    if _quote_all:
+        fmt.element_formatter = AlwaysQuotedFormatter()
+    else:
+        fmt.element_formatter = QuotedFormatter()
+    try:
+        return fmt.format(_pattern, **kwargs)
+    except KeyError as ex:
+        raise NameError(
+            f"The name {ex} is unknown in this context. Please "
+            "make sure that you defined that variable. "
+            "Also note that braces not used for variable access "
+            "have to be escaped by repeating them "
+        )
+
+
+#  adapted from Job.format_wildcards in snakemake.jobs
+def format_wildcards(string, job_properties):
+    """ Format a string with variables from the job. """
+
+    class Job(object):
+        def __init__(self, job_properties):
+            for key in job_properties:
+                setattr(self, key, job_properties[key])
+
+    job = Job(job_properties)
+    if "params" in job_properties:
+        job._format_params = Wildcards(fromdict=job_properties["params"])
+    else:
+        job._format_params = None
+    if "wildcards" in job_properties:
+        job._format_wildcards = Wildcards(fromdict=job_properties["wildcards"])
+    else:
+        job._format_wildcards = None
+    _variables = dict()
+    _variables.update(
+        dict(params=job._format_params, wildcards=job._format_wildcards)
+    )
+    if hasattr(job, "rule"):
+        _variables.update(dict(rule=job.rule))
+    try:
+        return format(string, **_variables)
+    except NameError as ex:
+        raise WorkflowError(
+            "NameError with group job {}: {}".format(job.jobid, str(ex))
+        )
+    except IndexError as ex:
+        raise WorkflowError(
+            "IndexError with group job {}: {}".format(job.jobid, str(ex))
+        )
+
+
+# adapted from ClusterExecutor.cluster_params function in snakemake.executor
+def format_values(dictionary, job_properties):
+    formatted = dictionary.copy()
+    for key, value in list(formatted.items()):
+        if key == "mem":
+            value = str(_convert_units_to_mb(value))
+        if isinstance(value, str):
+            try:
+                formatted[key] = format_wildcards(value, job_properties)
+            except NameError as e:
+                msg = "Failed to format cluster config " "entry for job {}.".format(
+                    job_properties["rule"]
+                )
+                raise WorkflowError(msg, e)
+    return formatted
+
+
+def convert_job_properties(job_properties, resource_mapping=None):
+    options = {}
+    if resource_mapping is None:
+        resource_mapping = {}
+    resources = job_properties.get("resources", {})
+    for k, v in resource_mapping.items():
+        options.update({k: resources[i] for i in v if i in resources})
+
+    if "threads" in job_properties:
+        options["cpus-per-task"] = job_properties["threads"]
+    return options
+
+
+def ensure_dirs_exist(path):
+    """Ensure output folder for Slurm log files exist."""
+    di = dirname(path)
+    if di == "":
+        return
+    if not os.path.exists(di):
+        os.makedirs(di, exist_ok=True)
+    return
+
+
+def format_sbatch_options(**sbatch_options):
+    """Format sbatch options"""
+    options = []
+    for k, v in sbatch_options.items():
+        val = ""
+        if v is not None:
+            val = f"={v}"
+        options.append(f"--{k}{val}")
+    return options
+
+
+def submit_job(jobscript, **sbatch_options):
+    """Submit jobscript and return jobid."""
+    options = format_sbatch_options(**sbatch_options)
+    try:
+        cmd = ["sbatch"] + ["--parsable"] + options + [jobscript]
+        res = sp.check_output(cmd)
+    except sp.CalledProcessError as e:
+        raise e
+    # Get jobid
+    res = res.decode()
+    try:
+        jobid = re.search(r"(\d+)", res).group(1)
+    except Exception as e:
+        raise e
+    return jobid
+
+
+def advanced_argument_conversion(arg_dict):
+    """Experimental adjustment of sbatch arguments to the given or default partition."""
+    # Currently not adjusting for multiple node jobs
+    nodes = int(arg_dict.get("nodes", 1))
+    if nodes > 1:
+        return arg_dict
+    partition = arg_dict.get("partition", None) or _get_default_partition()
+    constraint = arg_dict.get("constraint", None)
+    ncpus = int(arg_dict.get("cpus-per-task", 1))
+    runtime = arg_dict.get("time", None)
+    memory = _convert_units_to_mb(arg_dict.get("mem", 0))
+    config = _get_cluster_configuration(partition, constraint, memory)
+    mem = arg_dict.get("mem", ncpus * min(config["MEMORY_PER_CPU"]))
+    mem = _convert_units_to_mb(mem)
+    if mem > max(config["MEMORY"]):
+        logger.info(
+            f"requested memory ({mem}) > max memory ({max(config['MEMORY'])}); "
+            "adjusting memory settings"
+        )
+        mem = max(config["MEMORY"])
+
+    # Calculate available memory as defined by the number of requested
+    # cpus times memory per cpu
+    AVAILABLE_MEM = ncpus * min(config["MEMORY_PER_CPU"])
+    # Add additional cpus if memory is larger than AVAILABLE_MEM
+    if mem > AVAILABLE_MEM:
+        logger.info(
+            f"requested memory ({mem}) > "
+            f"ncpus x MEMORY_PER_CPU ({AVAILABLE_MEM}); "
+            "trying to adjust number of cpus up"
+        )
+        ncpus = int(math.ceil(mem / min(config["MEMORY_PER_CPU"])))
+    if ncpus > max(config["CPUS"]):
+        logger.info(
+            f"ncpus ({ncpus}) > available cpus ({max(config['CPUS'])}); "
+            "adjusting number of cpus down"
+        )
+        ncpus = min(int(max(config["CPUS"])), ncpus)
+    adjusted_args = {"mem": int(mem), "cpus-per-task": ncpus}
+
+    # Update time. If requested time is larger than maximum allowed time, reset
+    if runtime:
+        runtime = time_to_minutes(runtime)
+        time_limit = max(config["TIMELIMIT_MINUTES"])
+        if runtime > time_limit:
+            logger.info(
+                f"time (runtime) > time limit {time_limit}; " "adjusting time down"
+            )
+            adjusted_args["time"] = time_limit
+
+    # update and return
+    arg_dict.update(adjusted_args)
+    return arg_dict
+
+
+timeformats = [
+    re.compile(r"^(?P<days>\d+)-(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)$"),
+    re.compile(r"^(?P<days>\d+)-(?P<hours>\d+):(?P<minutes>\d+)$"),
+    re.compile(r"^(?P<days>\d+)-(?P<hours>\d+)$"),
+    re.compile(r"^(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)$"),
+    re.compile(r"^(?P<minutes>\d+):(?P<seconds>\d+)$"),
+    re.compile(r"^(?P<minutes>\d+)$"),
+]
+
+
+def time_to_minutes(time):
+    """Convert time string to minutes.
+
+    According to slurm:
+
+      Acceptable time formats include "minutes", "minutes:seconds",
+      "hours:minutes:seconds", "days-hours", "days-hours:minutes"
+      and "days-hours:minutes:seconds".
+
+    """
+    if not isinstance(time, str):
+        time = str(time)
+    d = {"days": 0, "hours": 0, "minutes": 0, "seconds": 0}
+    regex = list(filter(lambda regex: regex.match(time) is not None, timeformats))
+    if len(regex) == 0:
+        return
+    assert len(regex) == 1, "multiple time formats match"
+    m = regex[0].match(time)
+    d.update(m.groupdict())
+    minutes = (
+        int(d["days"]) * 24 * 60
+        + int(d["hours"]) * 60
+        + int(d["minutes"])
+        + math.ceil(int(d["seconds"]) / 60)
+    )
+    assert minutes > 0, "minutes has to be greater than 0"
+    return minutes
+
+
+def _get_default_partition():
+    """Retrieve default partition for cluster"""
+    cluster = CookieCutter.get_cluster_option()
+    cmd = f"sinfo -O partition {cluster}"
+    res = sp.check_output(cmd.split())
+    m = re.search(r"(?P<partition>\S+)\*", res.decode(), re.M)
+    partition = m.group("partition")
+    return partition
+
+
+def _get_cluster_configuration(partition, constraints=None, memory=0):
+    """Retrieve cluster configuration.
+
+    Retrieve cluster configuration for a partition filtered by
+    constraints, memory and cpus
+
+    """
+    try:
+        import pandas as pd
+    except ImportError:
+        print(
+            "Error: currently advanced argument conversion "
+            "depends on 'pandas'.", file=sys.stderr
+        )
+        sys.exit(1)
+
+    if constraints:
+        constraint_set = set(constraints.split(","))
+    cluster = CookieCutter.get_cluster_option()
+    cmd = f"sinfo -e -o %all -p {partition} {cluster}".split()
+    try:
+        output = sp.Popen(" ".join(cmd), shell=True, stdout=sp.PIPE).communicate()
+    except Exception as e:
+        print(e)
+        raise
+    data = re.sub("^CLUSTER:.+\n", "", re.sub(" \\|", "|", output[0].decode()))
+    df = pd.read_csv(StringIO(data), sep="|")
+    try:
+        df["TIMELIMIT_MINUTES"] = df["TIMELIMIT"].apply(time_to_minutes)
+        df["MEMORY_PER_CPU"] = df["MEMORY"] / df["CPUS"]
+        df["FEATURE_SET"] = df["AVAIL_FEATURES"].str.split(",").apply(set)
+    except Exception as e:
+        print(e)
+        raise
+    if constraints:
+        constraint_set = set(constraints.split(","))
+        i = df["FEATURE_SET"].apply(lambda x: len(x.intersection(constraint_set)) > 0)
+        df = df.loc[i]
+    memory = min(_convert_units_to_mb(memory), max(df["MEMORY"]))
+    df = df.loc[df["MEMORY"] >= memory]
+    return df


### PR DESCRIPTION
exome_setup_stager.py: this script parses input from Stager (family, participants, and linked files) to set up the analysis directory for running the crg2 exome pipeline. 

dnaseq_slurm_api.sh: not an actual script, but these are the commands I imagine we would add to Stager's [call to the slurm API](https://github.com/ccmbioinfo/stager/blob/master/flask/app/slurm.py#L24)

An example call to exome_setup_stager.py:

`python3 exome_setup_stager.py -a /hpf/largeprojects/ccmbio/mcouse/temp -f F1 -d '"P1":["file.bam", "file.vcf"]' '"P2":["file.bam"]'`

I've made a few assumptions here (structure of the arguments passed to exome_setup_stager.py, and that the user calling the script has crg2 set up in their home directory). 