### PR TITLE
Exome parser fix

### DIFF
--- a/parser_exomes.py
+++ b/parser_exomes.py
@@ -24,8 +24,8 @@ crg2_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
 def input_file(input_path):
     """Given hpf path, find input files"""
-    fq1 = sorted(glob.glob(os.path.join(input_path, "{*_1_*fastq.gz,*_R1_*fastq.gz}")))
-    fq2 = sorted(glob.glob(os.path.join(input_path, "{*_2_*fastq.gz,*_R2_*fastq.gz}")))
+    fq1 = sorted(glob.glob(os.path.join(input_path, "*_R1*.fastq.gz"))) + sorted(glob.glob(os.path.join(input_path, "*_1*.fastq.gz")))
+    fq2 = sorted(glob.glob(os.path.join(input_path, "*_R2*.fastq.gz"))) + sorted(glob.glob(os.path.join(input_path, "*_2*.fastq.gz")))
     bam = glob.glob(os.path.join(input_path, "*bam"))
     cram = glob.glob(os.path.join(input_path, "*cram"))
     # prioritize fastq as input, then bam, then cram

--- a/parser_exomes.py
+++ b/parser_exomes.py
@@ -35,7 +35,7 @@ def input_file(input_path):
         if len(fq1) == len(fq2):
             input["fastq"] = {"R1": fq1, "R2": fq2}
         else:
-            print(f"Number of R1 and R2 reads in {input_path} does not match")
+            print(f"Number of R1 and R2 files in {input_path} does not match")
             input = None
     elif len(bam) != 0:
         if len(bam) == 1:

--- a/parser_exomes.py
+++ b/parser_exomes.py
@@ -24,8 +24,8 @@ crg2_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
 def input_file(input_path):
     """Given hpf path, find input files"""
-    fq1 = sorted(glob.glob(os.path.join(input_path, "*1_*fastq.gz")))
-    fq2 = sorted(glob.glob(os.path.join(input_path, "*2_*fastq.gz")))
+    fq1 = sorted(glob.glob(os.path.join(input_path, "{*_1_*fastq.gz,*_R1_*fastq.gz}")))
+    fq2 = sorted(glob.glob(os.path.join(input_path, "{*_2_*fastq.gz,*_R2_*fastq.gz}")))
     bam = glob.glob(os.path.join(input_path, "*bam"))
     cram = glob.glob(os.path.join(input_path, "*cram"))
     # prioritize fastq as input, then bam, then cram

--- a/parser_exomes.py
+++ b/parser_exomes.py
@@ -24,8 +24,8 @@ crg2_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
 def input_file(input_path):
     """Given hpf path, find input files"""
-    fq1 = sorted(glob.glob(os.path.join(input_path, "*R1_*fastq.gz")))
-    fq2 = sorted(glob.glob(os.path.join(input_path, "*R2_*fastq.gz")))
+    fq1 = sorted(glob.glob(os.path.join(input_path, "*1_*fastq.gz")))
+    fq2 = sorted(glob.glob(os.path.join(input_path, "*2_*fastq.gz")))
     bam = glob.glob(os.path.join(input_path, "*bam"))
     cram = glob.glob(os.path.join(input_path, "*cram"))
     # prioritize fastq as input, then bam, then cram


### PR DESCRIPTION
The current exome parser will only recognize fastq.gz files that are named *_R1_*.fastq.gz and *_R2_*.fastq.gz. Some files are instead named *_1_*.fastq.gz and *_2_*.fastq.gz. I have added an extra glob command so that these will be recognized. I also tried simply making the glob more flexible, like this ->  *_*1_*.fastq.gz, so that one glob works for both formats, but this runs into an issue with files that have IDs in the filename ending in 1 or 2. I tested the parser out with 2 exomes, one with each format, it works fine. 

Also changed the wording of the read number error: the old wording made me think that the number of the actual reads in the fastq did not match, when really it is just trying to say that the number of R1 files does not match the number of R2 files. 