### PR TITLE
Modify exome parser so that it does not overwrite files in crg2 analysis directories that already exist

### DIFF
--- a/parser_exomes.py
+++ b/parser_exomes.py
@@ -338,7 +338,7 @@ if __name__ == "__main__":
         write_proj_files(sample_list, filepath)
         if submit_flag:
             print(f"\nSubmitting job for family: {i}")
-            # submit_jobs(filepath, i)
+            submit_jobs(filepath, i)
         else:
             print(f"Job for {i} not submitted")
 


### PR DESCRIPTION
For crg2 analysis directories that exist:

- Do not overwrite config.yaml, units.tsv, samples.tsv etc
- Do not re-submit job

Also, changed fastq parsing to "*_1*.fastq.gz" from "*_1.fastq.gz" as I ran into an issue while testing where it picked up the fastqs twice 