### PR TITLE
add sorting step to script

### DIFF
--- a/rules/multiqc_config.yaml
+++ b/rules/multiqc_config.yaml
@@ -1,4 +1,6 @@
 table_columns_visible:
   Peddy:
     error_sex_check: False
-
+    family_id: False
+  FastQC:
+    percent_duplicates: False

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -112,6 +112,7 @@ rule peddy:
         ped = peddy_ped
     output:
         "qc/peddy/{family}.html",
+        "qc/peddy/{family}.vs.html",
         "qc/peddy/{family}.het_check.csv",
         "qc/peddy/{family}.ped_check.csv",
         "qc/peddy/{family}.peddy.ped",
@@ -140,6 +141,7 @@ rule multiqc:
                                                             "qc/fastq_screen/{family}_{sample}_screen.txt",
                                                             "qc/bcftools_stats/{family}_{sample}.txt",
                                                             "qc/peddy/{family}.html",
+                                                            "qc/peddy/{family}.vs.html",
                                                             "qc/peddy/{family}.het_check.csv",
                                                             "qc/peddy/{family}.ped_check.csv",
                                                             "qc/peddy/{family}.peddy.ped",

--- a/scripts/callerwise_annotation.sh
+++ b/scripts/callerwise_annotation.sh
@@ -10,19 +10,19 @@ out_vcf=$4;
 echo "extracting variants for $caller"
 
 if [ ${caller} == "platypus" ]; then
-grep "${caller}" ${sites} | egrep -v "gatk-haplotype|samtools|freebayes" > ${outdir}/${caller}.annot.txt
+grep "${caller}" ${sites} | egrep -v "gatk-haplotype|samtools|freebayes" | sort -k 1,1 -k2,2n > ${outdir}/${caller}.annot.txt
 file=${outdir}/0003.vcf.gz
 
 elif [ ${caller} == "freebayes" ]; then
 file=${outdir}/0002.vcf.gz
-grep "${caller}" ${sites} | egrep -v "gatk-haplotype|samtools" > ${outdir}/${caller}.annot.txt
+grep "${caller}" ${sites} | egrep -v "gatk-haplotype|samtools" | sort -k 1,1 -k2,2n > ${outdir}/${caller}.annot.txt
 
 elif [ ${caller} == "samtools" ]; then
-grep ${caller} ${sites} | egrep -v "gatk-haplotype" > ${outdir}/${caller}.annot.txt
+grep ${caller} ${sites} | egrep -v "gatk-haplotype" | sort -k 1,1 -k2,2n > ${outdir}/${caller}.annot.txt
 file=${outdir}/0001.vcf.gz
 
 elif [ ${caller} == "gatk-haplotype" ]; then
-grep ${caller} ${sites} > ${outdir}/${caller}.annot.txt
+grep ${caller} ${sites} | sort -k 1,1 -k2,2n > ${outdir}/${caller}.annot.txt
 file=${outdir}/0000.vcf.gz
 
 else


### PR DESCRIPTION
A few exomes had errors in annot_caller step due to unsorted positions. Testing of the fix in callerwise_annotation.sh was successful