### PR TITLE
Pxu/fix ped

### DIFF
--- a/rules/common.smk
+++ b/rules/common.smk
@@ -196,14 +196,24 @@ def format_pedigree(wildcards):
             header=None,
             names=["fam_id", "individual_id", "pat_id", "mat_id", "sex", "phenotype"],
         )
-        ped=ped.drop(ped.index[3:])
-        ped["fam_id"] = family
-        for col in ["individual_id", "pat_id", "mat_id"]:
-            ped[col] = [parse_ped_id(individual_id, family) for individual_id in ped[col].values]
 
-        ped.to_csv(f"{family}.ped", sep=" ", index=False, header=False)
+    for col in ["individual_id", "pat_id", "mat_id"]:
+            ped[col] = [parse_ped_id(individual_id, family) for individual_id in ped[col].values]       
+        
+    for col in ["individual_id", "pat_id", "mat_id"]:
+        for row in range(len(ped[col])):
+                if len(ped[col][row].split("_")[-1]) != 1:
+                    pass   
+                else:
+                    ped[col][row] = ped[col][row].replace(ped[col][row], "0")
 
-        return f"{family}.ped"
+#ped=ped.drop(ped.index[3:])
+ped["fam_id"] = family
+
+
+    ped.to_csv(f"{family}.ped", sep=" ", index=False, header=False)
+
+    return f"{family}.ped"
 
 # create peddy.ped for peddy
 def peddy_ped(wildcards):

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -199,16 +199,17 @@ def format_pedigree(wildcards):
 
     for col in ["individual_id", "pat_id", "mat_id"]:
             ped[col] = [parse_ped_id(individual_id, family) for individual_id in ped[col].values]       
-        
+    
+    ped["fam_id"] = family
+
     for col in ["individual_id", "pat_id", "mat_id"]:
         for row in range(len(ped[col])):
-                if len(ped[col][row].split("_")[-1]) != 1:
-                    pass   
-                else:
-                    ped[col][row] = ped[col][row].replace(ped[col][row], "0")
+            if len(ped.loc[row, col].split("_")[-1]) != 1 and len(ped.loc[row, col].split("_")[-1]) != 2:
+                pass   
+            else:
+                ped.loc[row, col] = ped.loc[row, col].replace(ped.loc[row, col], "0")
 
-#ped=ped.drop(ped.index[3:])
-ped["fam_id"] = family
+    ped = ped.drop(ped.index[row] for row in ped.index if ped["individual_id"][row] == '0' )
 
 
     ped.to_csv(f"{family}.ped", sep=" ", index=False, header=False)


### PR DESCRIPTION
Added lines of code to reformat pedigree with extra lines. The format_pedigree function can now take in long form pedigree, change all lines with numbers (ie. 1 or 2 digits following "_" to '0') and drops all lines of numbers-only in "individual_id" column. Upon testing on 6 normal and long-form pedigrees, the function works well in dry-run. The "{family}_peddy.ped" created also looks good with dry-run. 

Hi Madeline, it'd be good if you could test this in genome 1922, or merge it if it looks good to you too, then I can finish running denovo reports for 1922 :)