### PR TITLE
Specify path to reference fasta when calling cre/cre.sh

### DIFF
--- a/rules/cre/snvreport.smk
+++ b/rules/cre/snvreport.smk
@@ -34,8 +34,8 @@ rule allsnvreport:
          ln -s ../../../{input.vcf} {params.family}-ensemble-annotated-decomposed.vcf.gz
          tabix {params.family}-ensemble-annotated-decomposed.vcf.gz
          cd ../
-         database={params.database_path} {params.cre}/cre.sh {params.family} 
-         database={params.database_path} type=wes.synonymous {params.cre}/cre.sh {params.family}
+         reference={params.ref} database={params.database_path} {params.cre}/cre.sh {params.family} 
+         reference={params.ref} database={params.database_path} type=wes.synonymous {params.cre}/cre.sh {params.family}
          unset type
          '''
 

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -26,11 +26,11 @@ rule allsnvreport:
          ln -s {project}-gatk-haplotype-annotated-decomposed.vcf.gz.tbi {project}-ensemble-annotated-decomposed.vcf.gz.tbi
          cd ../
          if [ {wildcards.p} == "coding" ]; then  
-         database={params.database_path} {params.cre}/cre.sh {project} 
+         reference={params.ref} database={params.database_path} {params.cre}/cre.sh {project} 
          elif [ {wildcards.p} == "denovo" ]; then  
-         database={params.database_path} type=denovo {params.cre}/cre.sh {project} 
+         reference={params.ref} database={params.database_path} type=denovo {params.cre}/cre.sh {project} 
          else
-         database={params.database_path} type=wgs {params.cre}/cre.sh {project}
+         reference={params.ref} database={params.database_path} type=wgs {params.cre}/cre.sh {project}
          unset type
          fi;
          '''


### PR DESCRIPTION
 cre/cre.sh calls ~/cre/vcf.ensemble.getCALLERS.sh, which requires a path to a reference fasta