### PR TITLE
Modified BQSR compression level to 5

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -119,7 +119,7 @@ params:
     markSplitReads: "-M"
     maxMem: ""
   gatk:
-    java_opts: "-Xms500m -Xmx9555m"
+    java_opts: "-Xms500m -Xmx9555m -Dsamjdk.compression_level=5"
     HaplotypeCaller: ""
     BaseRecalibrator: ""
     #BaseRecalibrator: "--interval-set-rule INTERSECTION -U LENIENT-VCF-PROCESSING --read-filter BadCigar --read-filter NotzPrimaryAlignment"


### PR DESCRIPTION
- Changed the compression level to 5 for the BQSR step in config.yaml file.
- Performed benchmarking using NA12878 dataset and validation and report comparison on exome 428

Closes #137 