### PR TITLE
Add fastq regex

### DIFF
--- a/parser_exomes.py
+++ b/parser_exomes.py
@@ -46,7 +46,6 @@ def input_file(input_path):
             else:
                 print(f"Unrecognized fastq file format")
                 input = None
-        print(fq1, fq2)
         if len(fq1) == len(fq2):
             input["fastq"] = {"R1": sorted(fq1), "R2": sorted(fq2)}
         else:
@@ -337,7 +336,7 @@ if __name__ == "__main__":
         write_proj_files(sample_list, filepath)
         if submit_flag:
             print(f"\nSubmitting job for family: {i}")
-            submit_jobs(filepath, i)
+            #submit_jobs(filepath, i)
         else:
             print(f"Job for {i} not submitted")
 


### PR DESCRIPTION
Incorporates regex to differentiate between R1 and R2 reads, and account for reads where identifiers lack R prefix (_1_ and _2_, e.g. 670513-P_HVWLCBCXX-2-ID01_1_sequence.fastq.gz).