### PR TITLE
Check dup script prints sample name + dup rate for all samples

### DIFF
--- a/utils/check_dup_rate.sh
+++ b/utils/check_dup_rate.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 family=$1
 multiqc=`echo $family/qc/multiqc/multiqc_data/multiqc_picard_dups.txt`
-dups=`cat $multiqc | awk -F '\t' '{print $10}'`
-for d in $dups
+dups=(`cat $multiqc | awk -F '\t' '{print $10}'`)
+samples=(`cat $multiqc | awk -F '\t' '{print $1}'`)
+num_of_samples=$((`echo ${#samples[@]}`-1))
+
+for i in `seq 1 $num_of_samples`
 do
-	if [ "$d" != "PERCENT_DUPLICATION" ]; then
-		dups=`awk "BEGIN {print ${d}*100}" | cut -d '.' -f1`
-		if (( $dups >= "20")); then
-			echo "A sample in ${family} has greater than 20% duplication rate, run coverage metrics: $d"
-		fi
+	dup_rate=`awk "BEGIN {print ${dups[i]}*100}" | cut -d '.' -f1`
+	sample=`echo ${samples[i]}`
+	if (( $dup_rate >= "20")); then
+		echo "$sample in $family has greater than 20% duplication rate, run coverage metrics: ${dups[i]}"
+	else
+		echo "$sample in $family duplication rate OK: ${dups[i]}"
 	fi
 done
 


### PR DESCRIPTION
Modified the check_dup_script.sh file to print sample names along with duplication rates for all samples in the family.