### PR TITLE
Pxu/ped check

### DIFF
--- a/parser_genomes.py
+++ b/parser_genomes.py
@@ -72,7 +72,7 @@ def setup_directories(family, sample_list, filepath, step):
         exit()
     if len(ped) == 0:
         print(f"No ped files found: {ped}. Exiting!")
-        exit()
+        break
     if len(ped) == 1 and os.path.isfile(config):
         ped = ped[0]
         pedi = pd.read_csv(
@@ -101,11 +101,9 @@ def setup_directories(family, sample_list, filepath, step):
                     break
                 else:
                     print(f"Individuals in ped file do not match with samples.tsv, double check: {ped}. Exiting!")
-                    #exit()
                     break
             else:                         
                 print(f"Ped file is either not a trio or not linked, double check: {ped}. Exiting!")
-                #exit()
                 break
 
     # bam: start after folder creation and symlink for step

--- a/parser_genomes.py
+++ b/parser_genomes.py
@@ -85,7 +85,8 @@ def setup_directories(family, sample_list, filepath, step):
             individual_id = str(row.individual_id)
             pat_id = str(row.pat_id)
             mat_id = str(row.mat_id)
-            if not((individual_id.isnumeric() and len(individual_id) == 1) | (pat_id.isnumeric() and len(pat_id) == 1) | (mat_id.isnumeric() and len(mat_id) == 1 )):
+            # individual_id, pat_id and mat_id cannot be both numeric and single number
+            if not ((individual_id.isnumeric() and len(individual_id) == 1) | (pat_id.isnumeric() and len(pat_id) == 1) | (mat_id.isnumeric() and len(mat_id) == 1 )):
                 #write and check sample
                 write_sample(filepath, family) 
                 samples = os.path.join(filepath, family, "samples.tsv")


### PR DESCRIPTION
Added functionality to parser_genome.py to do pedigree check and sample check. I created a ~/gene_data/pedigrees/ folder in my personal account's home and tested on /hpf/largeprojects/ccmbio/pxu/C4R/exome_assignments/ped-check-samples_for_crg2.tsv . This file contains genomes with missing pedigree, wrong samples names in the pedigree, non-linked ped, trios and quads. Test runs look good.

Running the script will show both the sample names from samples.tsv and from pedigree. When encountering a wrong ped, the script will  go on to submit job without ped. Users can cancel these families while jobs are still in queue, and submit them individually afterwards. 

Let me know your thoughts and any additional cases/features we need to incorporate! 