### PR TITLE
Remove hpf hardcoded values for ehdn

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,7 @@ tools:
   cre: "~/cre"
   crg: "~/crg"
   crg2: "~/crg2"
+  ehdn: "/hpf/largeprojects/ccmbio/arun/Tools/EHDN.TCAG/ExpansionHunterDenovo-v0.7.0"
 
 ref:
   name: GRCh37.75
@@ -107,6 +108,8 @@ annotation:
     catalog: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.hg19.masked.json"
     trf: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.tsv"
     1000g: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/1000G_EH_v1.0.tsv"
+  ehdn:
+    files: "/srv/shared/data/dccdipg/annotation/ExpansionHunterDenovo/"
   cre:
      database_path: "/hpf/largeprojects/ccm_dccforge/dccforge/results/database/"
 

--- a/envs/ehdn.yaml
+++ b/envs/ehdn.yaml
@@ -1,0 +1,6 @@
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - python =3.7.7
+  - scipy =1.7.3

--- a/rules/str.smk
+++ b/rules/str.smk
@@ -44,21 +44,28 @@ rule EH_report:
         echo "Copying final report to filaname with timestamp: $outfile" > {log}
         cp {output.xlsx} $outfile
         '''
+
 rule EHdn:
     input: expand("decoy_rm/{family}_{sample}.no_decoy_reads.bam",family=config["run"]["project"], sample=samples.index)
     output:
         json = "str/EHDN/{family}_EHDN_str.tsv"
     params:
         crg = config["tools"]["crg"],
+        ehdn = config["tools"]["ehdn"],
+        ehdn_files = config["annotation"]["ehdn"]["files"],
+        ref = config["ref"]["genome"],
         # ref = config["ref"]["genome"],
         # irr_mapq = config["params"]["EHDN"]["irr_mapq"],
         # anchor_mapq = config["params"]["EHDN"]["anchor_mapq"],
     log:
         "logs/str/{family}-EHdn.log"
+    conda:
+        "../envs/ehdn.yaml"
     shell:
         '''
-        sh {params.crg}/crg.ehdn.sh {wildcards.family} crg2
+        EHDN={params.ehdn} EHDN_files={params.ehdn_files} ref={params.ref} script_dir={params.crg} sh {params.crg}/crg.ehdn.sh {wildcards.family} crg2
         '''
+
 rule EHdn_report:
     input: "str/EHDN/{family}_EHDN_str.tsv".format(family=config["run"]["project"])
     output: "report/str/{family}.EHDN.xlsx"


### PR DESCRIPTION
Provides paths to EHDN 0.70 executable, EHDN jsons called on 1000G samples, and reference fasta as arguments to crg/crg.ehdn.sh. 