### PR TITLE
Automate coverage report generation for exomes 

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -11,7 +11,8 @@ if config["run"]["pipeline"] == "wes":
         input:
             "report/coding/{}".format(project),
             "qc/multiqc/multiqc.html",
-            [expand("recal/{family}_{sample}.bam.md5".format(family=config["run"]["project"], sample=s)) for s in samples.index]
+            [expand("recal/{family}_{sample}.bam.md5".format(family=config["run"]["project"], sample=s)) for s in samples.index],
+            [expand("coverage/{family}_{sample}/{family}_{sample}.median".format(family=config["run"]["project"], sample=s)) for s in samples.index]
 elif config["run"]["pipeline"] == "wgs":
     rule all:
         input:

--- a/Snakefile
+++ b/Snakefile
@@ -6,13 +6,14 @@ samples = pd.read_table(config["run"]["samples"]).set_index("sample", drop=False
 
 ##### Target rules #####
 project = config["run"]["project"]
+
 if config["run"]["pipeline"] == "wes":
     rule all:
         input:
             "report/coding/{}".format(project),
             "qc/multiqc/multiqc.html",
             [expand("recal/{family}_{sample}.bam.md5".format(family=config["run"]["project"], sample=s)) for s in samples.index],
-            "minio/{}".format(project)
+            expand("{minio}/{family}", minio=[config["run"]["minio"]], family=project) if config["run"]["minio"] else []
 elif config["run"]["pipeline"] == "wgs":
     rule all:
         input:
@@ -45,12 +46,12 @@ rule write_version:
 ##### Modules #####
 
 if config["run"]["pipeline"] == "wes":
-    include: "rules/mapping.smk"
-    include: "rules/stats.smk"
-    include: "rules/qc.smk"
+    #include: "rules/mapping.smk"
+    #include: "rules/stats.smk"
+    #include: "rules/qc.smk"
     base = "rules/cre/"
-    include: base + "calling.smk"
-    include: base + "filtering.smk"
+    #include: base + "calling.smk"
+    #include: base + "filtering.smk"
 elif config["run"]["pipeline"] == "wgs":
     include: "rules/mapping.smk"
     include: "rules/stats.smk"

--- a/Snakefile
+++ b/Snakefile
@@ -46,12 +46,12 @@ rule write_version:
 ##### Modules #####
 
 if config["run"]["pipeline"] == "wes":
-    #include: "rules/mapping.smk"
-    #include: "rules/stats.smk"
-    #include: "rules/qc.smk"
+    include: "rules/mapping.smk"
+    include: "rules/stats.smk"
+    include: "rules/qc.smk"
     base = "rules/cre/"
-    #include: base + "calling.smk"
-    #include: base + "filtering.smk"
+    include: base + "calling.smk"
+    include: base + "filtering.smk"
 elif config["run"]["pipeline"] == "wgs":
     include: "rules/mapping.smk"
     include: "rules/stats.smk"

--- a/Snakefile
+++ b/Snakefile
@@ -12,7 +12,7 @@ if config["run"]["pipeline"] == "wes":
             "report/coding/{}".format(project),
             "qc/multiqc/multiqc.html",
             [expand("recal/{family}_{sample}.bam.md5".format(family=config["run"]["project"], sample=s)) for s in samples.index],
-            [expand("coverage/{family}_{sample}/{family}_{sample}.median".format(family=config["run"]["project"], sample=s)) for s in samples.index]
+            "minio/{}".format(project)
 elif config["run"]["pipeline"] == "wgs":
     rule all:
         input:

--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,7 @@ ref:
   gatk-known: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/Mills_and_1000G_gold_standard.indels.vcf.gz"
   old_cram_ref: "UR:/mnt/hnas/reference/hg19/hg19.fa"
   new_cram_ref: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/hg19/seq/hg19.fa"
+  bed_index: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/seq/GRCh37.fa.bedtoolsindex"
 
 filtering:
   vqsr: false

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ run:
   flank: 100000
   gatk: "gatk"
   pipeline: "wes" #either wes (exomes) or wgs (genomes) or annot (to annotate and produce reports for an input vcf)
+  minio: ""
 
 genes:
   ensembl: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/Homo_sapiens.GRCh37.87.gtf_subset.csv"

--- a/config.yaml
+++ b/config.yaml
@@ -138,6 +138,8 @@ params:
     PrintReads: " -jdk_deflater -jdk_inflater -U LENIENT_VCF_PROCESSING --read_filter BadCigar --read_filter NotPrimaryAlignment "
   picard:
     MarkDuplicates: "REMOVE_DUPLICATES=false"
+    ValidationStringency: "VALIDATION_STRINGENCY=SILENT"
+    AssumeSortOrder: "ASSUME_SORT_ORDER=coordinate"
     java_opts: "-Xmx2g"
   qualimap:
     mem: "20G"

--- a/envs/coverage.yaml
+++ b/envs/coverage.yaml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python ==2.7.15
+  - bedtools ==2.29.0
+  - numpy >1.1

--- a/pbs_profile/pbs_config.yaml
+++ b/pbs_profile/pbs_config.yaml
@@ -52,3 +52,6 @@ manta:
 
 peddy:
   mem: "60g"
+
+minio:
+  mem: "60g"

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -256,3 +256,11 @@ def get_gatk_vcf(wildcards):
     elif config["run"]["pipeline"] == "wgs":
         vcf = expand("genotyped/{family}.vcf.gz", family=wildcards.family)
     return vcf
+
+def get_gatk_vcf_tbi(wildcards):
+    """ Get vcf from gatk4 calling for the use in qc """
+    if config["run"]["pipeline"] == "wes":
+        vcf_tbi = expand("genotyped/{family}-gatk_haplotype.vcf.gz.tbi", family=wildcards.family)
+    elif config["run"]["pipeline"] == "wgs":
+        vcf_tbi = expand("genotyped/{family}.vcf.gz.tbi", family=wildcards.family)
+    return vcf_tbi

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,5 +1,6 @@
 
 import pandas as pd
+import os
 from snakemake.utils import validate
 from snakemake.utils import min_version
 from datetime import date
@@ -223,11 +224,12 @@ def peddy_ped(wildcards):
     sample_id = [family + "_" + str(sample) for sample in sample_id]
 
     ped = config["run"]["ped"]
-    if ped == "":
+    if os.path.exists(f"{family}_peddy.ped"):
+        pass
+    elif ped == "":
         data = {'#Family_ID': family, 'Individual_ID':sample_id, 'Paternal_ID': '-9', 'Maternal_ID': '-9', 'Sex': '0', 'Phenotype': '0', 'Ethnicity': '-9'}
         data_df = pd.DataFrame(data)
         data_df.to_csv(f"{family}_peddy.ped", sep="\t", index=False, header=True)
-
     else:
         ped = format_pedigree(wildcards) #family +'.ped' #f"{family}.ped"
         ped = pd.read_csv(

--- a/rules/cre/snvreport.smk
+++ b/rules/cre/snvreport.smk
@@ -1,6 +1,14 @@
 #gatk VCF is missing because it is symlinked to ensemble VCF
 callers = [ gatk + "_haplotype", "samtools", "freebayes", "platypus" ] 
 
+def copy_cov(wildcards):
+    dups = pd.read_csv("qc/dedup/{family}_{sample}.metrics.txt", sep='\t', comment='#')
+    dups_perc =[float(dup) for dup in dups["PERCENT_DUPLICATION"].values.tolist()]
+    if max(dups_perc) >= 0.2:
+        return ["coverage/", "report/coding/{family}"]
+    else:
+        return ["report/coding/{family}"]
+
 rule allsnvreport:
     input:
         db="annotated/coding/{family}-gemini.db",
@@ -38,5 +46,30 @@ rule allsnvreport:
          cre={params.cre} reference={params.ref} database={params.database_path} type=wes.synonymous {params.cre}/cre.sh {params.family}
          unset type
          '''
+
+rule minio:
+    input: 
+        copy_cov
+    output:
+        directory("/hpf/largeprojects/ccmbio/mcouse/C4R/development/test_coverage_report/minio/{family}")
+    log:
+        "logs/minio/{family}.log"
+    run:
+        import os 
+        import glob
+        import shutil
+        outdir=output[0]
+        os.mkdir(outdir)
+        for f in input:
+            if "report" in f:
+                reports = glob.glob(os.path.join(f, '*wes*'))
+                for r in reports:
+                    print(f"copying {r} to MinIO")
+                    shutil.copy(r, outdir)
+            else:
+                print("copying coverage reports to MinIO")
+                shutil.copytree(f, os.path.join(outdir, "coverage"), copy_function = shutil.copy)
+
+            
 
 

--- a/rules/cre/snvreport.smk
+++ b/rules/cre/snvreport.smk
@@ -60,7 +60,7 @@ checkpoint dup_perc:
 def check_dup(wildcards):
     with checkpoints.dup_perc.get(**wildcards).output[0].open() as f:
         if f.read().strip() == "TRUE":
-            return expand("coverage/{family}_{sample}/",sample=samples.index,family=project) +  ["report/coding/{family}"]
+            return expand("coverage/{family}_{sample}/",sample=samples.index,family=project) +  ["report/coding/{family}"] + ["qc/multiqc/multiqc.html"]
         else:
             return ["report/coding/{family}"]
 
@@ -86,6 +86,9 @@ rule minio:
                 for r in reports:
                     print(f"copying {r} to MinIO")
                     shutil.copy(r, outdir)
+            elif "qc" in f:
+                print(f"copying {r} to MinIO")
+                shutil.copy(f, outdir)
             else:
                 coverage_sample = os.path.join(outdir, f)
                 coverage_parent = os.path.join(outdir, "coverage")

--- a/rules/cre/snvreport.smk
+++ b/rules/cre/snvreport.smk
@@ -70,7 +70,7 @@ rule minio:
         # if duplication rate is >20% in any sample, generate coverage metrics and copy these to MinIO
         check_dup
     output:
-        directory("minio/{family}")
+        directory(config['run']['minio'] + "/{family}")
     log:
         "logs/minio/{family}.log"
     run:
@@ -78,7 +78,8 @@ rule minio:
         import glob
         import shutil
         outdir=output[0]
-        os.mkdir(outdir)
+        if not os.path.exists(outdir):
+            os.mkdir(outdir)
         for f in input:
             if "report" in f:
                 reports = glob.glob(os.path.join(f, '*wes*'))
@@ -86,8 +87,12 @@ rule minio:
                     print(f"copying {r} to MinIO")
                     shutil.copy(r, outdir)
             else:
+                coverage_sample = os.path.join(outdir, f)
+                coverage_parent = os.path.join(outdir, "coverage")
+                if not os.path.exists(coverage_parent):
+                    os.mkdir(coverage_parent)
                 print("copying coverage reports to MinIO")
-                shutil.copytree(f, os.path.join(outdir, "coverage"), copy_function = shutil.copy)
+                shutil.copytree(f, coverage_sample, copy_function = shutil.copy)
 
             
 

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -151,7 +151,8 @@ rule multiqc:
     params:
         config["params"]["multiqc"]["config"]
     output:
-        report("qc/multiqc/multiqc.html", caption="../report/multiqc.rst", category="Quality control") 
+        report = report("qc/multiqc/multiqc.html", caption="../report/multiqc.rst", category="Quality control"),
+        stats = "qc/multiqc/multiqc_data/multiqc_general_stats.txt"
     log:
         "logs/multiqc/multiqc.log"
     wrapper:

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -183,9 +183,7 @@ rule calculate_coverage:
     params:
         crg2_dir=config['tools']['crg2']
     output:
-        coverage=temp("coverage/{family}_{sample}/{family}_{sample}.dedup.cov"),
         coverage_dir=directory("coverage/{family}_{sample}/"),
-        median="coverage/{family}_{sample}/{family}_{sample}.median"
     log:
         "logs/coverage/{family}_{sample}.log"
     conda:
@@ -195,19 +193,20 @@ rule calculate_coverage:
         mkdir -p coverage/{wildcards.family}_{wildcards.sample}/
         cd coverage/{wildcards.family}_{wildcards.sample}/
 
-        bedtools coverage -d -sorted -a {input.bed} -b ../../{input.bam} -g {input.bed_index} > {wildcards.family}_{wildcards.family}.dedup.cov
+        bedtools coverage -d -sorted -a {input.bed} -b ../../{input.bam} -g {input.bed_index} > {wildcards.family}_{wildcards.sample}.dedup.cov
 
-        python {params.crg2_dir}/utils/bam.coverage.base_wise.stat.py {wildcards.family}_{wildcards.family}.dedup.cov 5 $'\\t' > {wildcards.family}_{wildcards.family}.coverage_stats.csv
+        python {params.crg2_dir}/utils/bam.coverage.base_wise.stat.py {wildcards.family}_{wildcards.sample}.dedup.cov 5 $'\\t' > {wildcards.family}_{wildcards.sample}.coverage_stats.csv
 
-        echo {wildcards.family}_{wildcards.family}.dedup.cov","`cat {wildcards.family}_{wildcards.family}.dedup.cov | awk -F '\\t' '{{if ($6<20) {{print $4","$1":"$2+$5","$6}}}}' | wc -l` > {wildcards.family}_{wildcards.family}.less20x.stats.csv
-        {params.crg2_dir}/utils/bam.coverage.less20.sh {wildcards.family}_{wildcards.family}.dedup.cov > {wildcards.family}_{wildcards.family}.less20x_coverage.csv
+        echo {wildcards.family}_{wildcards.sample}.dedup.cov","`cat {wildcards.family}_{wildcards.sample}.dedup.cov | awk -F '\\t' '{{if ($6<20) {{print $4","$1":"$2+$5","$6}}}}' | wc -l` > {wildcards.family}_{wildcards.sample}.less20x.stats.csv
+        {params.crg2_dir}/utils/bam.coverage.less20.sh {wildcards.family}_{wildcards.sample}.dedup.cov > {wildcards.family}_{wildcards.sample}.less20x_coverage.csv
 
-        {params.crg2_dir}/utils/bam.coverage.per_exon.sh {wildcards.family}_{wildcards.family}.dedup.cov > {wildcards.family}_{wildcards.family}.per_exon_coverage.csv
-        cat {wildcards.family}_{wildcards.family}.per_exon_coverage.csv | sed 1d  > {wildcards.family}_{wildcards.family}.per_exon_coverage.csv.tmp
-        python {params.crg2_dir}/utils/bam.coverage.base_wise.stat.py {wildcards.family}_{wildcards.family}.per_exon_coverage.csv.tmp 2 ',' > {wildcards.family}_{wildcards.family}.per_exon.distribution.csv
-        rm {wildcards.family}_{wildcards.family}.per_exon_coverage.csv.tmp
+        {params.crg2_dir}/utils/bam.coverage.per_exon.sh {wildcards.family}_{wildcards.sample}.dedup.cov > {wildcards.family}_{wildcards.sample}.per_exon_coverage.csv
+        cat {wildcards.family}_{wildcards.sample}.per_exon_coverage.csv | sed 1d  > {wildcards.family}_{wildcards.sample}.per_exon_coverage.csv.tmp
+        python {params.crg2_dir}/utils/bam.coverage.base_wise.stat.py {wildcards.family}_{wildcards.sample}.per_exon_coverage.csv.tmp 2 ',' > {wildcards.family}_{wildcards.sample}.per_exon.distribution.csv
+        rm {wildcards.family}_{wildcards.sample}.per_exon_coverage.csv.tmp
 
-        median_line=`cat {wildcards.family}_{wildcards.family}.dedup.cov | wc -l`
+        median_line=`cat {wildcards.family}_{wildcards.sample}.dedup.cov | wc -l`
         median_line=$(($median_line/2))
-        cat {wildcards.family}_{wildcards.family}.dedup.cov | awk '{{print $6}}' | sort -n | sed -n ${{median_line}}p > {wildcards.family}_{wildcards.family}.median
+        cat {wildcards.family}_{wildcards.sample}.dedup.cov | awk '{{print $6}}' | sort -n | sed -n ${{median_line}}p > {wildcards.family}_{wildcards.sample}.median
+        rm {wildcards.family}_{wildcards.sample}.dedup.cov
         """

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -156,3 +156,18 @@ rule multiqc:
         "logs/multiqc/multiqc.log"
     wrapper:
         get_wrapper_path("multiqc")
+
+
+rule remove_duplicates:
+    input: 
+        recal/{family}_{sample}.bam
+    params:
+        markDuplicates="REMOVE_DUPLICATES=false"
+        validationStringency=config["params"]["picard"]["ValidationStringency"]
+    output:
+        bam=temp(dups_removed/{family}_{sample}.bam),
+        metrics=dups_removed/{family}_{sample}.dup.metrics.txt
+    log:
+        logs/remove_duplicates/{family}_{sample}.log
+    wrapper:
+        get_wrapper_path("picard", "markduplicates")

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -109,7 +109,8 @@ rule bcftools_stats:
 rule peddy:
     input:
         vcf = get_gatk_vcf,
-        ped = peddy_ped
+        ped = peddy_ped,
+        vcf_tbi = get_gatk_vcf_tbi
     output:
         "qc/peddy/{family}.html",
         "qc/peddy/{family}.vs.html",

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -184,6 +184,7 @@ rule calculate_coverage:
         crg2_dir=config['tools']['crg2']
     output:
         coverage=temp("coverage/{family}_{sample}/{family}_{sample}.dedup.cov"),
+        coverage_dir=directory("coverage/{family}_{sample}/"),
         median="coverage/{family}_{sample}/{family}_{sample}.median"
     log:
         "logs/coverage/{family}_{sample}.log"

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -160,14 +160,53 @@ rule multiqc:
 
 rule remove_duplicates:
     input: 
-        recal/{family}_{sample}.bam
+        "recal/{family}_{sample}.bam"
     params:
-        markDuplicates="REMOVE_DUPLICATES=false"
-        validationStringency=config["params"]["picard"]["ValidationStringency"]
+        markDuplicates="REMOVE_DUPLICATES=true",
+        java_opts = config["params"]["picard"]["java_opts"],
+        validationStringency=config["params"]["picard"]["ValidationStringency"],
+        assumeSortOrder=config["params"]["picard"]["AssumeSortOrder"]
     output:
-        bam=temp(dups_removed/{family}_{sample}.bam),
-        metrics=dups_removed/{family}_{sample}.dup.metrics.txt
+        bam="dups_removed/{family}_{sample}.bam",
+        metrics="dups_removed/{family}_{sample}.dup.metrics.txt"
     log:
-        logs/remove_duplicates/{family}_{sample}.log
+        "logs/remove_duplicates/{family}_{sample}.log"
     wrapper:
         get_wrapper_path("picard", "markduplicates")
+
+
+rule calculate_coverage:
+    input:
+        bam="dups_removed/{family}_{sample}.bam",
+        bed=config["annotation"]["svreport"]["exon_bed"],
+        bed_index=config["ref"]["bed_index"]
+    params:
+        crg2_dir=config['tools']['crg2']
+    output:
+        coverage=temp("coverage/{family}_{sample}/{family}_{sample}.dedup.cov"),
+        median="coverage/{family}_{sample}/{family}_{sample}.median"
+    log:
+        "logs/coverage/{family}_{sample}.log"
+    conda:
+        "../envs/coverage.yaml"
+    shell:
+        """
+        mkdir -p coverage/{wildcards.family}_{wildcards.sample}/
+        cd coverage/{wildcards.family}_{wildcards.sample}/
+
+        bedtools coverage -d -sorted -a {input.bed} -b ../../{input.bam} -g {input.bed_index} > {wildcards.family}_{wildcards.family}.dedup.cov
+
+        python {params.crg2_dir}/utils/bam.coverage.base_wise.stat.py {wildcards.family}_{wildcards.family}.dedup.cov 5 $'\\t' > {wildcards.family}_{wildcards.family}.coverage_stats.csv
+
+        echo {wildcards.family}_{wildcards.family}.dedup.cov","`cat {wildcards.family}_{wildcards.family}.dedup.cov | awk -F '\\t' '{{if ($6<20) {{print $4","$1":"$2+$5","$6}}}}' | wc -l` > {wildcards.family}_{wildcards.family}.less20x.stats.csv
+        {params.crg2_dir}/utils/bam.coverage.less20.sh {wildcards.family}_{wildcards.family}.dedup.cov > {wildcards.family}_{wildcards.family}.less20x_coverage.csv
+
+        {params.crg2_dir}/utils/bam.coverage.per_exon.sh {wildcards.family}_{wildcards.family}.dedup.cov > {wildcards.family}_{wildcards.family}.per_exon_coverage.csv
+        cat {wildcards.family}_{wildcards.family}.per_exon_coverage.csv | sed 1d  > {wildcards.family}_{wildcards.family}.per_exon_coverage.csv.tmp
+        python {params.crg2_dir}/utils/bam.coverage.base_wise.stat.py {wildcards.family}_{wildcards.family}.per_exon_coverage.csv.tmp 2 ',' > {wildcards.family}_{wildcards.family}.per_exon.distribution.csv
+        rm {wildcards.family}_{wildcards.family}.per_exon_coverage.csv.tmp
+
+        median_line=`cat {wildcards.family}_{wildcards.family}.dedup.cov | wc -l`
+        median_line=$(($median_line/2))
+        cat {wildcards.family}_{wildcards.family}.dedup.cov | awk '{{print $6}}' | sort -n | sed -n ${{median_line}}p > {wildcards.family}_{wildcards.family}.median
+        """

--- a/utils/bam.coverage.base_wise.stat.py
+++ b/utils/bam.coverage.base_wise.stat.py
@@ -1,0 +1,38 @@
+#!/bin/env python
+
+# $1 = file.bam.coverage = product of ~/bioscripts/bam.coverage.sh with -d on
+# $2 = No of the field with coverage, 0-based
+# $3 = character separator in the input file
+
+import sys
+import numpy
+
+cov={}
+
+levels = [0,1,10,20,30,50,100,200]
+for i in levels:
+    cov[i]=0
+
+total_bases=0
+
+coverage_field_num = int(sys.argv[2])
+sep = sys.argv[3]
+
+with open(sys.argv[1],'rb') as f_coverage:
+    for line in f_coverage:
+	total_bases += 1
+	buf = line.strip()
+	fields = buf.split(sep)
+	coverage = int(fields[coverage_field_num])
+
+	for j in levels:
+	    if (coverage >= j):
+		cov[j] += 1
+
+f_coverage.close()
+
+print("Coverage,bases at,%")
+
+for i in levels:
+    print(str(i)+','+str(cov[i])+','+str(1.0*cov[i]/total_bases))
+

--- a/utils/bam.coverage.base_wise.stat.py
+++ b/utils/bam.coverage.base_wise.stat.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+# script credit: https://github.com/naumenko-sa/bioscripts
 
 # $1 = file.bam.coverage = product of ~/bioscripts/bam.coverage.sh with -d on
 # $2 = No of the field with coverage, 0-based

--- a/utils/bam.coverage.less20.sh
+++ b/utils/bam.coverage.less20.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# reports holes in coverage: how many PB are below 20X per exon
+
+echo "target,gene,pos,min_coverage,bases_below20" 
+
+cat $1 | awk -F "\t" '{print $1"-"$2"-"$3","$4","$2+$5","$6}' | \
+awk -F ',' '
+BEGIN{
+    prev_target=0;
+    prev_pos=0;
+    prev_cov=0;
+    prev_gene=0;
+    prev_bases_below20=0;
+}
+{
+    target=$1
+    if (prev_target != target && prev_target !=0){
+	    print prev_target","prev_gene","prev_pos","prev_cov","prev_bases_below20;
+	    prev_target=0;
+    	    prev_pos=0;
+    	    prev_cov=0;
+    	    prev_gene=0;
+    	    prev_bases_below20=0;
+    }
+
+    if ($4 < 20){
+	prev_bases_below20+=1;
+	if (prev_target !=0) {
+	    if ($4 < prev_cov){
+		prev_cov = $4
+		prev_pos = $3
+	    }
+	}else{
+	    prev_target=target;
+    	    prev_pos=$3;
+	    prev_cov=$4;
+	    prev_gene=$2;
+	}
+    }
+}
+END{
+    if (prev_target !=0){
+	print prev_target","prev_gene","prev_pos","prev_cov","prev_bases_below20;
+    }
+}'

--- a/utils/bam.coverage.less20.sh
+++ b/utils/bam.coverage.less20.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# script credit: https://github.com/naumenko-sa/bioscripts
 
 # reports holes in coverage: how many PB are below 20X per exon
 

--- a/utils/bam.coverage.per_exon.sh
+++ b/utils/bam.coverage.per_exon.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# reports the distribution of lowest coverage in exons
+# each exon is characterized by a bp with the lowest coverage
+# distribution of theses values for 
+# input is dcoverage
+
+echo "target,gene,min_coverage"
+
+cat $1 | awk -F "\t" '{print $1"-"$2"-"$3","$4","$2+$5","$6}' | \
+awk -F ',' '
+BEGIN{
+    prev_target=0;
+    prev_pos=0;
+    prev_cov=0;
+    prev_gene=0;
+    prev_bases_below20=0;
+}
+{
+    target=$1
+    if (prev_target != target){
+	    if (prev_target !=0){
+		print prev_target","prev_gene","prev_cov;
+	    }
+	    prev_target=target;
+    	    prev_cov=$4;
+    	    prev_gene=$2;
+    }
+    if ($4 < prev_cov){
+		prev_cov = $4
+    }
+}
+END{
+    print prev_target","prev_gene","prev_cov;
+}'
+

--- a/utils/bam.coverage.per_exon.sh
+++ b/utils/bam.coverage.per_exon.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# script credit: https://github.com/naumenko-sa/bioscripts
 
 # reports the distribution of lowest coverage in exons
 # each exon is characterized by a bp with the lowest coverage

--- a/wrappers/multiqc/wrapper.py
+++ b/wrappers/multiqc/wrapper.py
@@ -11,7 +11,7 @@ from os import path
 from snakemake.shell import shell
 
 
-input_dirs = set(path.dirname(fp) for fp in snakemake.input)
+input_dirs = set(path.dirname(fp) for fp in snakemake.input.report)
 output_dir = path.dirname(snakemake.output[0])
 output_name = path.basename(snakemake.output[0])
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)

--- a/wrappers/multiqc/wrapper.py
+++ b/wrappers/multiqc/wrapper.py
@@ -11,9 +11,9 @@ from os import path
 from snakemake.shell import shell
 
 
-input_dirs = set(path.dirname(fp) for fp in snakemake.input.report)
-output_dir = path.dirname(snakemake.output[0])
-output_name = path.basename(snakemake.output[0])
+input_dirs = set(path.dirname(fp) for fp in snakemake.input)
+output_dir = path.dirname(snakemake.output.report)
+output_name = path.basename(snakemake.output.report)
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 shell(

--- a/wrappers/peddy/wrapper.py
+++ b/wrappers/peddy/wrapper.py
@@ -8,9 +8,8 @@ extra = snakemake.params.get("extra", "")
 
 family = snakemake.wildcards.family
 dir = os.path.dirname(snakemake.output[0])
-prefix = path.join(dir, family) #qc/peddy/412
+prefix = path.join(dir, family)  # qc/peddy/412
 
-shell("tabix -f {snakemake.input.vcf} && peddy {snakemake.params} --prefix {prefix} {snakemake.input.vcf} {snakemake.input.ped} {log} ")
-
-
-
+shell(
+    "peddy {snakemake.params} --prefix {prefix} {snakemake.input.vcf} {snakemake.input.ped} {log} "
+)

--- a/wrappers/picard/markduplicates/wrapper.py
+++ b/wrappers/picard/markduplicates/wrapper.py
@@ -6,9 +6,15 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 
+remove_dups = snakemake.params.markDuplicates
+remove_dups_flag = remove_dups.split("=")[1]
 
-shell(
-    "picard MarkDuplicates {snakemake.params.markDuplicates} {snakemake.params.java_opts}   INPUT={snakemake.input} "
-    "OUTPUT={snakemake.output.bam} METRICS_FILE={snakemake.output.metrics} "
-    "&> {snakemake.log}"
-)
+if remove_dups_flag == "false":
+    # mark duplicates for variant calling
+    command = "picard MarkDuplicates {remove_dups} {snakemake.params.java_opts}   INPUT={snakemake.input} OUTPUT={snakemake.output.bam} METRICS_FILE={snakemake.output.metrics} "
+else:
+    # remove duplicates for the purposes of calculating coverage metrics
+    command = "picard MarkDuplicates {remove_dups} {snakemake.params.java_opts} {snakemake.params.validationStringency}  {snakemake.params.assumeSortOrder} INPUT={snakemake.input} OUTPUT={snakemake.output.bam} METRICS_FILE={snakemake.output.metrics} "
+
+print(remove_dups)
+shell("(" + command + ") &> {snakemake.log}")


### PR DESCRIPTION
This PR adds the following:

- A rule to generate bam files with duplicates removed: rules/qc/remove_duplicates
- A rule to generate coverage reports from bams with duplicates removed: rules/qc/calculate_coverage
- A rule to copy the report to MinIO: rules/cre/snvreport/minio
- An input function to check whether only variant reports should be copied to MinIO, or variant reports, coverage reports, and multiqc report: rules/cre/snvreport/check_qual
- A checkpoint that is evaluated by check_qual so that Snakemake knows whether or not to generate coverage reports
- A parameter config["run"]["minio"]  that specifies base path to MinIO directory. If empty, reports won't be copied anywhere.

Tested on family 2086 (dup percentage >20% in at least one sample) with MinIO path arbitrarily set to /hpf/largeprojects/ccmbio/mcouse/C4R/development/2086. Test run is in /hpf/largeprojects/ccmbio/mcouse/C4R/development/test_coverage_report_2086. 

Also tested on family 2638 (dup percentage all below 20%). Test run is in /hpf/largeprojects/ccmbio/mcouse/C4R/development/test_coverage_report_2638. 

Noting that I had to make changes to peddy so that the input file (created by function peddy_ped) does not get recreated each time the workflow is evaluated, and to the wrapper so that it does not re-index the input VCF file, which results in all rules downstream being re-run when the checkpoint is evaluated at the minio rule. 

After pushing to master and pulling to cre-snakemake-slurm: 
- revise exome_setup_stager.py to add minio path to config.yaml
- copy properly sorted /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/exons/hg19_UCSC_exons_canonical_placeholder.bed to CHEO-RI space