### PR TITLE
Fix EHDN files path

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,7 +111,7 @@ annotation:
     trf: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.tsv"
     1000g: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/1000G_EH_v1.0.tsv"
   ehdn:
-    files: "/srv/shared/data/dccdipg/annotation/ExpansionHunterDenovo/"
+    files: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunterDenovo/"
   cre:
      database_path: "/hpf/largeprojects/ccm_dccforge/dccforge/results/database/"
 


### PR DESCRIPTION
config["annotation"]["ehdn"]["files"] had the CHEO-RI path, not the hpf path. This led to the str/EHDN/<family>_manifest.txt file lacking the 1000G samples, which disrupted outlier detection downstream. 