### PR TITLE
changed cre deleted database path to central annotations directory

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -113,7 +113,7 @@ annotation:
   ehdn:
     files: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunterDenovo/"
   cre:
-     database_path: "/hpf/largeprojects/ccm_dccforge/dccforge/results/database/"
+     database_path: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/"
 
 validation:
   benchmark: "benchmark.tsv"


### PR DESCRIPTION
This directory was accidentally deleted following the deletion of the dccforge/results cleanup. We have retrieved the C4R exome counts and HGMD databases from the CHEO-RI space, and copied them to the central crg2 annotations directory. Submitting this PR to change the cre database path prefix to that directory. 