### PR TITLE
Use samtools REF_CACHE to decompress CRAM

### DIFF
--- a/config_cheo_ri.yaml
+++ b/config_cheo_ri.yaml
@@ -35,8 +35,7 @@ ref:
   canon_bed: "/srv/shared/data/dccdipg/genomes/grch37.canon.bed"
   split_genome: "/srv/shared/data/dccdipg/genomes/split_genome/"
   gatk-known: "/srv/shared/data/dccdipg/annotation/vcfanno/Mills_and_1000G_gold_standard.indels.vcf.gz"
-  old_cram_ref: "UR:/mnt/hnas/reference/hg19/hg19.fa"
-  new_cram_ref: "/srv/shared/data/dccdipg/genomes/hg19.fa"
+  ref_cache: "/srv/shared/data/dccdipg/genomes/GRCh37d5/REF_CACHE/cache/%2s/%2s/%s:/srv/shared/data/dccdipg/genomes/hg19/REF_CACHE/cache/%2s/%2s/%s"
   bed_index: "/srv/shared/data/dccdipg/genomes/GRCh37/GRCh37.fa.bedtoolsindex"
 
 filtering:

--- a/config_hpf.yaml
+++ b/config_hpf.yaml
@@ -35,8 +35,7 @@ ref:
   canon_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/grch37.canon.bed"
   split_genome: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/split_genome"
   gatk-known: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/Mills_and_1000G_gold_standard.indels.vcf.gz"
-  old_cram_ref: "UR:/mnt/hnas/reference/hg19/hg19.fa"
-  new_cram_ref: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/hg19/seq/hg19.fa"
+  ref_cache: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/REF_CACHE/GRCh37d5/%2s/%2s/%s:/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/REF_CACHE/hg19/%2s/%2s/%s"
   bed_index: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/seq/GRCh37.fa.bedtoolsindex"
 
 filtering:

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -5,8 +5,7 @@ rule input_prep:
     params:
         outdir = temp("fastq/"),
         sort_check = True,
-        old_cram_ref = config["ref"]["old_cram_ref"],
-        new_cram_ref = config["ref"]["new_cram_ref"]
+        ref_cache = config["ref"]["ref_cache"]
     output:
         fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
         fastq2 = temp("fastq/{family}_{sample}_R2.fastq.gz")


### PR DESCRIPTION
Rather than resorting to the @SQ UR field in the CRAM header, use REF_CACHE/REF_PATH. Samtools first looks to the REF_CACHE, then EBI, than the UR field (https://www.htslib.org/workflow/cram.html). Using a REF_CACHE should avoid samtools attempting to query EBI and hanging. 