### PR TITLE
Replace symbolic INS with N

### DIFF
--- a/wrappers/snpeff/wrapper.py
+++ b/wrappers/snpeff/wrapper.py
@@ -2,8 +2,14 @@ from snakemake.shell import shell
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
+# replace symbolic <INS> alleles so that snpeff will annotate against genes
+# https://github.com/pcingola/SnpEff/issues/344
+replace_ins = "zcat {snakemake.input} | sed 's/<INS>/N/g' > tmp.vcf; "
+gzip_vcf = "bgzip tmp.vcf; "
+mv_vcf = "mv tmp.vcf.gz {snakemake.input}; "
+
 shell(
-    "(snpEff {snakemake.params.java_opts} "
+    "(" + replace_ins + gzip_vcf + mv_vcf + "snpEff {snakemake.params.java_opts} "
     "-i VCF "
     "-o VCF "
     "-dataDir {snakemake.params.data_dir} "


### PR DESCRIPTION
[snpeff will not annotate \<INS\>](https://github.com/pcingola/SnpEff/issues/344), so replace \<INS\> with N so that we at least get the gene(s) that the insertion falls into. Without this fix, the insertions aren't annotated against any gene, and so in the report appear to be intergenic. 