### PR TITLE
Dark region annotation for PacBio hg38 pipeline

### DIFF
--- a/vcfanno/pacbio.vcfanno.conf
+++ b/vcfanno/pacbio.vcfanno.conf
@@ -162,3 +162,10 @@ file="C4R_genome_counts_sorted_LIFTED.tsv.gz"
 columns = [5,6]
 names = ["c4r_wgs_samples", "c4r_wgs_counts"]
 ops=["first", "first"]
+
+#Dark Genes
+[[annotation]]
+file = "Alliance_Dark_Genes_LR_Pnl_TargetsCaptured_hg38_ann.bed.gz"
+columns = [4]
+names = ["Dark_genes"]
+ops = ["self"]


### PR DESCRIPTION
- Modified the vcfanno config file to include dark region annotations for PacBio crg2 reports
- This branch should be used in conjunction with the cre (hg38-pacbio-dark-regions) branch