### PR TITLE
added function to decompress .ora files

### DIFF
--- a/config_hpf.yaml
+++ b/config_hpf.yaml
@@ -26,7 +26,7 @@ tools:
   ehdn: "/hpf/largeprojects/ccmbio/arun/Tools/EHDN.TCAG/ExpansionHunterDenovo-v0.7.0"
   mity: "/hpf/largeprojects/ccmbio/ajain/mity/mity_package/bin"
   melt: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/MELT/MELTv2.2.2/MELT.jar"
-  orad: "/hpf/largeprojects/ccmbio/ajain/tools/orad_2_6_1/orad" 
+  orad: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/orad_2_6_1/orad" 
 
 
 ref:
@@ -42,7 +42,7 @@ ref:
   ref_cache: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/REF_CACHE/GRCh37d5/%2s/%2s/%s:/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/REF_CACHE/hg19/%2s/%2s/%s"
   bed_index: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/seq/GRCh37.fa.bedtoolsindex"
   melt_element_ref: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/MELT/transposon_file_list.txt"
-  orad_ref: "/hpf/largeprojects/ccmbio/ajain/tools/orad_2_6_1/oradata"
+  orad_ref: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/orad_2_6_1/oradata"
 
 filtering:
   vqsr: false

--- a/config_hpf.yaml
+++ b/config_hpf.yaml
@@ -26,6 +26,7 @@ tools:
   ehdn: "/hpf/largeprojects/ccmbio/arun/Tools/EHDN.TCAG/ExpansionHunterDenovo-v0.7.0"
   mity: "/hpf/largeprojects/ccmbio/ajain/mity/mity_package/bin"
   melt: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/MELT/MELTv2.2.2/MELT.jar"
+  orad: "/hpf/largeprojects/ccmbio/ajain/tools/orad_2_6_1/orad" 
 
 
 ref:
@@ -41,6 +42,7 @@ ref:
   ref_cache: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/REF_CACHE/GRCh37d5/%2s/%2s/%s:/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/REF_CACHE/hg19/%2s/%2s/%s"
   bed_index: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/seq/GRCh37.fa.bedtoolsindex"
   melt_element_ref: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/MELT/transposon_file_list.txt"
+  orad_ref: "/hpf/largeprojects/ccmbio/ajain/tools/orad_2_6_1/oradata"
 
 filtering:
   vqsr: false

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -5,7 +5,9 @@ rule input_prep:
     params:
         outdir = temp("fastq/"),
         sort_check = True,
-        ref_cache = config["ref"]["ref_cache"]
+        ref_cache = config["ref"]["ref_cache"],
+        orad = config["tools"]["orad"],
+        orad_ref = config["ref"]["orad_ref"]
     output:
         fastq1 = temp("fastq/{family}_{sample}_R1.fastq.gz"),
         fastq2 = temp("fastq/{family}_{sample}_R2.fastq.gz")

--- a/wrappers/samtools/fastq/fastq_prep.py
+++ b/wrappers/samtools/fastq/fastq_prep.py
@@ -80,12 +80,12 @@ def concatenate_fastq(r1, r2, family, sample):
         log_message(f"Input {r1}, {r2} given for {sample} is not handled. Exiting!")
         exit()
 
-def decompress_ora(r1,r2):
+def decompress_ora(r1,r2,orad,orad_ref):
     decompressed_r1_list=[]
     decompressed_r2_list=[]
     for read in r1:
         log_message(f"{read}")
-        command = f"/hpf/largeprojects/ccmbio/ajain/tools/orad_2_6_1/orad --ora-reference /hpf/largeprojects/ccmbio/ajain/tools/orad_2_6_1/oradata {read}"
+        command = f"{orad} --ora-reference {orad_ref} {read}"
         log_message(f"Command:{command}")
         run_orad=subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, shell=True)
         log_message(run_orad.stdout)
@@ -96,7 +96,7 @@ def decompress_ora(r1,r2):
 
     for read in r2:
         log_message(f"{read}")
-        command = f"/hpf/largeprojects/ccmbio/ajain/tools/orad_2_6_1/orad --ora-reference /hpf/largeprojects/ccmbio/ajain/tools/orad_2_6_1/oradata {read}"
+        command = f"{orad} --ora-reference {orad_ref} {read}"
         log_message(f"Command:{command}")
         run_orad=subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, shell=True)
         log_message(run_orad.stdout)
@@ -113,7 +113,7 @@ def remove_bgzipped_files(decompressed_r1_list,decompressed_r2_list):
         command=f"rm {read}"
         subprocess.run(command,shell=True)
 
-def main(units, sample, family):
+def main(units, sample, family, orad, orad_ref):
     logfile = f"logs/input_prep/{family}_{sample}.log"
     logging.basicConfig(
         filename=logfile,
@@ -141,7 +141,7 @@ def main(units, sample, family):
     elif os.path.splitext(r1[0])[1] == ".ora":
         #If file is ora compressed, then first decompress it
         log_message(f"Files for {sample} are in ora format. Decompressing the files using orad")
-        decompressed_r1, decompressed_r2=decompress_ora(r1,r2)
+        decompressed_r1, decompressed_r2=decompress_ora(r1,r2,orad,orad_ref)
         concatenate_fastq(decompressed_r1, decompressed_r2, family, sample)
         #remove the bgzipped files
         remove_bgzipped_files(decompressed_r1,decompressed_r2)
@@ -151,4 +151,6 @@ if __name__ == "__main__":
     units = snakemake.input.units
     sample = snakemake.wildcards.sample
     family = snakemake.wildcards.family
-    main(units, sample, family)
+    orad = snakemake.wildcards.orad
+    orad_ref = snakemake.wildcards.orad_ref
+    main(units, sample, family, orad, orad_ref)

--- a/wrappers/samtools/fastq/wrapper.py
+++ b/wrappers/samtools/fastq/wrapper.py
@@ -69,4 +69,6 @@ with open(snakemake.log[0], "w") as f:
 
     elif input_type == ["fq1", "fq2"]:
         print("File type is fastq")
-        fastq_prep.main(units, sample, family)
+        orad=snakemake.params.orad
+        orad_ref=snakemake.params.orad_ref
+        fastq_prep.main(units, sample, family, orad, orad_ref)


### PR DESCRIPTION
The ora format is a reference-based compression format for FASTQ files. It is a lossless compression format, designed for very fast compression/decompression and high compression ratio. These files can be easily converted to bgzipped format using the [Dragen ORA Decompression Software](https://support-docs.illumina.com/SW/Decompression_v261/Content/SW/ORA/Decompression_Overview.htm) 

Installation directory: `/hpf/largeprojects/ccmbio/ajain/tools/orad_2_6_1`

Code modifications were done in fastq_prep.py file:
- Script first checks if the read extension is .gz or .ora
- If its .gz, then it concatenates the reads as usual
- If its .ora, it first decompresses the individual files, concatenates the reads and finally removes the .gz files from the main directory