### PR TITLE
Adjust resources for annot_caller rule

### DIFF
--- a/rules/cre/filtering.smk
+++ b/rules/cre/filtering.smk
@@ -85,7 +85,7 @@ if len(get_cre_vcfs()) > 1:
             "../../envs/common.yaml"
         shell:
             '''
-            cat {input.all_sites} | parallel -k -j 16  {params.crg2}/scripts/annotate-caller.sh {{}} >> {output.all_sites}
+            cat {input.all_sites} | parallel -k -j 50 {params.crg2}/scripts/annotate-caller.sh {{}} >> {output.all_sites}
             echo -e '##INFO=<ID=CALLERS,Number=.,Type=String,Description="Variant called by"\\n##INFO=<ID=NUMCALLS,Number=1,Type=Integer,Description="Number of callers at this location">' > {output.hdr}
             for i in {params.callers}; do 
                 sh {params.crg2}/scripts/callerwise_annotation.sh ${{i}} {output.all_sites} isec isec/${{i}}.annot.vcf.gz

--- a/slurm_profile/slurm-config.yaml
+++ b/slurm_profile/slurm-config.yaml
@@ -48,6 +48,10 @@ manta:
 recalibrate_base_qualities:
   time: "100:00:00"
 
+annot_caller:
+  time: "60:00:00"
+  mem: "12G"
+
 
 
 


### PR DESCRIPTION
Issue: Annot_caller rule takes a very long time to complete

Fix:
- Increased time and memory for annot_caller rule in slurm_profile/slurm-config.yaml file
- Increased the number of jobs running in parallel from 15 to 50 in rules/cre/filtering.smk

Testing:
- Tested fix on 4 exomes for the Hiraki Lab which all ran to completion