### PR TITLE
 Incorporate LINSIGHT into annotation pipeline

### DIFF
--- a/dnaseq_slurm_hpf.sh
+++ b/dnaseq_slurm_hpf.sh
@@ -14,4 +14,8 @@ source /hpf/largeprojects/ccm_dccforge/dccdipg/Common/anaconda3/etc/profile.d/co
 conda activate snakemake
 #target annotated/coding/vcfanno/NA12878.coding.vep.vcfanno.vcf
 
-snakemake --use-conda -s ${SF} --cores 4 --conda-prefix ${CP} --configfile ${CONFIG} --profile ${SLURM}
+snakemake --use-conda -s ${SF} --cores 4 --conda-prefix ${CP} --configfile ${CONFIG} --profile ${SLURM} -p --dry-run 
+
+# annotated/coding/vcfanno/NA12878.coding.vep.vcfanno.vcf
+#/hpf/largeprojects/ccmbio/GIAB_benchmark_datasets/hg19/WGS/NA12878
+#/hpf/largeprojects/ccmbio/GIAB_benchmark_datasets/hg19/WGS/NA12878/RMNISTHS_30xdownsample.bam

--- a/dnaseq_slurm_hpf.sh
+++ b/dnaseq_slurm_hpf.sh
@@ -12,5 +12,6 @@ CONFIG=config_hpf.yaml
 
 source /hpf/largeprojects/ccm_dccforge/dccdipg/Common/anaconda3/etc/profile.d/conda.sh
 conda activate snakemake
+#target annotated/coding/vcfanno/NA12878.coding.vep.vcfanno.vcf
 
 snakemake --use-conda -s ${SF} --cores 4 --conda-prefix ${CP} --configfile ${CONFIG} --profile ${SLURM}

--- a/dnaseq_slurm_hpf.sh
+++ b/dnaseq_slurm_hpf.sh
@@ -12,10 +12,5 @@ CONFIG=config_hpf.yaml
 
 source /hpf/largeprojects/ccm_dccforge/dccdipg/Common/anaconda3/etc/profile.d/conda.sh
 conda activate snakemake
-#target annotated/coding/vcfanno/NA12878.coding.vep.vcfanno.vcf
 
-snakemake --use-conda -s ${SF} --cores 4 --conda-prefix ${CP} --configfile ${CONFIG} --profile ${SLURM} -p --dry-run 
-
-# annotated/coding/vcfanno/NA12878.coding.vep.vcfanno.vcf
-#/hpf/largeprojects/ccmbio/GIAB_benchmark_datasets/hg19/WGS/NA12878
-#/hpf/largeprojects/ccmbio/GIAB_benchmark_datasets/hg19/WGS/NA12878/RMNISTHS_30xdownsample.bam
+snakemake --use-conda -s ${SF} --cores 4 --conda-prefix ${CP} --configfile ${CONFIG} --profile ${SLURM}

--- a/vcfanno/crg.vcfanno_hg38.conf
+++ b/vcfanno/crg.vcfanno_hg38.conf
@@ -88,6 +88,13 @@ names = ["phyloP30way_mammalian","phastCons30way_mammalian","Vest4_score","REVEL
 columns = [159,165,67,82,155]
 ops = ["self","self","self","self","self"]
 
+#GRCh38 - LinSight Score
+[[annotation]]
+file = "GRCh38_LinSight.bed.gz"
+names = ["LinSight_Score"]
+columns = [4]
+ops = ["self"]
+
 # spliceAI
 [[annotation]]
 file = "spliceai_scores.masked.indel.hg38.vcf.gz"


### PR DESCRIPTION
Following the steps in https://github.com/orgs/ccmbioinfo/projects/5/views/1?pane=issue&itemId=54524505

I tested the pipeline with this change, and here is the output

```
Building DAG of jobs...
Checking status of 0 jobs.
Using shell: /usr/bin/bash
Provided cluster nodes: 4
Provided resources: cpus=64
Job counts:
        count   jobs
        25      combine_calls
        25      gatk
        25      genotype_variants
        2       hard_filter_calls
        1       input_prep
        1       map_reads
        1       mark_duplicates
        1       merge_calls
        1       merge_variants
        1       mosdepth
        1       pass
        1       recalibrate_base_qualities
        1       samtools_index
        2       select_calls
        1       vcfanno
        1       vep
        1       vt
        91
Resources before job selection: {'cpus': 64, '_cores': 9223372036854775807, '_nodes': 4}
Ready jobs (1):
        input_prep
Selected jobs (1):
"crg2-9534537.out" 78L, 3040C
```


