### PR TITLE
Adding FATHMM-XF into annotation pipeline with new branch: rvaran/FATHMM-XF

### DIFF
--- a/vcfanno/crg.vcfanno_hg38.conf
+++ b/vcfanno/crg.vcfanno_hg38.conf
@@ -155,3 +155,10 @@ file="C4R_genome_counts_sorted_LIFTED.tsv.gz"
 columns = [5,6]
 names = ["c4r_wgs_samples", "c4r_wgs_counts"]
 ops=["first", "first"]
+
+#FATHMM-XF scores
+[[annotation]]
+file = "GRCh38_FATHMM-XF_NC_edited.tsv.gz"
+names = ["FATHMM_XF"]
+columns = [5]
+ops = ["self"]


### PR DESCRIPTION
Adding FATHMM-XF scores into crg2 pipeline, where scores will be present within the INFO# field of the vcfs. Files containing scores relocated to /hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/GRCh38_FATHMM-XF_NC_edited.tsv.gz. Appropriate additions made to vcfanno config file, as presented below:

<img width="591" alt="Screenshot 2024-03-26 at 6 00 21 PM" src="https://github.com/ccmbioinfo/crg2/assets/155133355/d6bc672b-15af-4656-b8be-8998ee39914d">

