### PR TITLE
add ncER, ReMM, and LINSIGHT scores

### DIFF
--- a/vcfanno/cre.vcfanno.conf
+++ b/vcfanno/cre.vcfanno.conf
@@ -114,4 +114,23 @@ columns = [3]
 names = ["UCE_200bp"]
 ops = ["flag"]
 
+# ncER
+[[annotation]]
+file = "GRCh37_ncER_perc.bed.gz"
+names = ["ncER"]
+columns = [4]
+ops = ["max"]
 
+# ReMM
+[[annotation]]
+file = "ReMM.v0.4.hg19.tsv.gz"
+names = ["ReMM"]
+columns = [3]
+ops = ["max"]
+
+# LINSIGHT
+[[annotation]]
+file = "GRCh37_LinSight.bed.gz"
+names = ["LinSight_Score"]
+columns = [4]
+ops = ["max"]

--- a/vcfanno/crg.vcfanno.conf
+++ b/vcfanno/crg.vcfanno.conf
@@ -126,7 +126,6 @@ columns=[3]
 names=["CTCF_binding_site"]
 ops=["flag"]
 
-
 #Enhancer
 [[annotation]]
 file="Enhancer.hg19.all.celltypes.formatted.bed.gz"
@@ -141,10 +140,30 @@ columns = [4]
 names = ["tf_binding_sites"]
 ops=["concat"]
 
-
 #C4R WGS counts and samples
 [[annotation]]
 file="seen_in_c4r-genomes-20211110.tsv.gz"
 columns = [5,6]
 names = ["c4r_wgs_samples", "c4r_wgs_counts"]
 ops=["first", "first"]
+
+# ncER
+[[annotation]]
+file = "GRCh37_ncER_perc.bed.gz"
+names = ["ncER"]
+columns = [4]
+ops = ["max"]
+
+# ReMM
+[[annotation]]
+file = "ReMM.v0.4.hg19.tsv.gz"
+names = ["ReMM"]
+columns = [3]
+ops = ["max"]
+
+# LINSIGHT
+[[annotation]]
+file = "GRCh37_LinSight.bed.gz"
+names = ["LinSight_Score"]
+columns = [4]
+ops = ["max"]


### PR DESCRIPTION
Add non-coding scores (nCER, ReMM, LINSIGHT) to WGS reports (panel, panel-flank, de novo). Scores are not added for exomes or WGS coding reports. 