### PR TITLE
Alphamissense annotation for hg38

### DIFF
--- a/vcfanno/cre.vcfanno_hg38.conf
+++ b/vcfanno/cre.vcfanno_hg38.conf
@@ -121,3 +121,10 @@ file="C4R_wes_counts_LIFTED_rmspace_sorted.tsv.gz"
 columns = [5,6]
 names = ["c4r_wes_samples", "c4r_wes_counts"]
 ops=["first", "first"]
+
+#AlphaMissense
+[[annotation]]
+file="AlphaMissense_hg19.tsv.gz"
+columns = [9]
+names = ["AlphaMissense"]
+ops=["first"]

--- a/vcfanno/crg.vcfanno_hg38.conf
+++ b/vcfanno/crg.vcfanno_hg38.conf
@@ -176,3 +176,10 @@ file = "GRCh38_FATHMM-XF_NC_edited.tsv.gz"
 names = ["FATHMM_XF"]
 columns = [5]
 ops = ["self"]
+
+#AlphaMissense
+[[annotation]]
+file="AlphaMissense_hg19.tsv.gz"
+columns = [9]
+names = ["AlphaMissense"]
+ops=["first"]

--- a/vcfanno/crg.vcfanno_hg38.conf
+++ b/vcfanno/crg.vcfanno_hg38.conf
@@ -179,7 +179,7 @@ ops = ["self"]
 
 #AlphaMissense
 [[annotation]]
-file="AlphaMissense_hg19.tsv.gz"
+file="AlphaMissense_hg38.tsv.gz"
 columns = [9]
 names = ["AlphaMissense"]
 ops=["first"]


### PR DESCRIPTION
- For testing, please checkout crg2 branch "crg2-hg38-alphamissense" branch and cre branch "hg38-alphamissense"
- Tested pipeline on one genome from Mital Lab and Alphamissense annotation column was successfully added to the report (wes.regular) as well as the annotated VCF file.