### PR TITLE
Update gnomAD SV annotations to v4.1

### DIFF
--- a/hg38/config_hpf.yaml
+++ b/hg38/config_hpf.yaml
@@ -113,7 +113,7 @@ annotation:
     exon_bed: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/hg38_exons_from_biomart_20220802.txt"
     exac: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExAC/fordist_cleaned_nonpsych_z_pli_rec_null_data.txt"
     omim: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/OMIM_2020-04-09/genemap2.txt"
-    gnomad: "/hpf/largeprojects/ccmbio/ajain/crg2_hg38/gnomad_v4.1/gnomad_SV/gnomad.v4.1.sv.sites.nochr.bed"
+    gnomad: "/hpf/largeprojects/ccmbio/ajain/crg2_hg38/gnomad_v4.1/gnomad_SV/gnomad.v4.1.sv.sites.processed.bed"
     biomart: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/BioMaRt.GrCh38.p13.ensembl.mim.hgnc.entrez.tsv.gz"
     mssng_manta_counts: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/Canadian_MSSNG_parent_SVs.Manta.counts.txt"
     mssng_lumpy_counts: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/Canadian_MSSNG_parent_SVs.LUMPY.counts.txt"

--- a/hg38/config_hpf.yaml
+++ b/hg38/config_hpf.yaml
@@ -113,7 +113,7 @@ annotation:
     exon_bed: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/hg38_exons_from_biomart_20220802.txt"
     exac: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExAC/fordist_cleaned_nonpsych_z_pli_rec_null_data.txt"
     omim: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/OMIM_2020-04-09/genemap2.txt"
-    gnomad: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/gnomad_v2_sv.sites_hg38_liftover_nochr_FINAL.bed"
+    gnomad: "/hpf/largeprojects/ccmbio/ajain/crg2_hg38/gnomad_v4.1/gnomad_SV/gnomad.v4.1.sv.sites.nochr.bed"
     biomart: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/BioMaRt.GrCh38.p13.ensembl.mim.hgnc.entrez.tsv.gz"
     mssng_manta_counts: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/Canadian_MSSNG_parent_SVs.Manta.counts.txt"
     mssng_lumpy_counts: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/Canadian_MSSNG_parent_SVs.LUMPY.counts.txt"

--- a/scripts/SVRecords/SVAnnotator.py
+++ b/scripts/SVRecords/SVAnnotator.py
@@ -480,7 +480,7 @@ class SVAnnotator:
             "FREQ_HOMREF",
             "FREQ_HET",
             "FREQ_HOMALT",
-            "POPMAX_AF",
+            "GRPMAX_AF",
         ]
         gnomad_ann_cols = [
             "gnomAD_SVTYPE",
@@ -493,11 +493,15 @@ class SVAnnotator:
             "gnomAD_FREQ_HOMREF",
             "gnomAD_FREQ_HET",
             "gnomAD_FREQ_HOMALT",
-            "gnomAD_POPMAX_AF",
+            "gnomAD_GRPMAX_AF",
         ]
         gnomad_df = pd.read_csv(gnomad, sep="\t", dtype="str").astype(str)
         gnomad_df.columns = gnomad_df.columns.str.replace("#", "")
         gnomad_df.columns = gnomad_df.columns.str.strip()
+        gnomad_df.rename({"chrom": "CHROM", "start": "START", "end": "END", "name": "NAME", "svtype": "SVTYPE", "samples": "SAMPLES" }, axis=1, inplace=True)
+        gnomad_df["CHROM"] = gnomad_df["CHROM"].str.replace("chr", "")
+        # in gnomAD v4.1 bed file, 'END' and 'SVTYPE' columns are duplicated
+        gnomad_df = gnomad_df.loc[:, ~gnomad_df.columns.duplicated()]
         gnomad_df = gnomad_df[gnomad_cols]
         gnomad_bed = BedTool(gnomad_df.itertuples(index=False))
 

--- a/scripts/SVRecords/SVAnnotator.py
+++ b/scripts/SVRecords/SVAnnotator.py
@@ -498,12 +498,6 @@ class SVAnnotator:
             "gnomAD_FILTER"
         ]
         gnomad_df = pd.read_csv(gnomad, sep="\t", dtype="str").astype(str)
-        gnomad_df.columns = gnomad_df.columns.str.replace("#", "")
-        gnomad_df.columns = gnomad_df.columns.str.strip()
-        gnomad_df.rename({"chrom": "CHROM", "start": "START", "end": "END", "name": "NAME", "svtype": "SVTYPE", "samples": "SAMPLES" }, axis=1, inplace=True)
-        gnomad_df["CHROM"] = gnomad_df["CHROM"].str.replace("chr", "")
-        # in gnomAD v4.1 bed file, 'END' and 'SVTYPE' columns are duplicated
-        gnomad_df = gnomad_df.loc[:, ~gnomad_df.columns.duplicated()]
         gnomad_df = gnomad_df[gnomad_cols]
         gnomad_bed = BedTool(gnomad_df.itertuples(index=False))
 

--- a/scripts/SVRecords/SVAnnotator.py
+++ b/scripts/SVRecords/SVAnnotator.py
@@ -481,6 +481,7 @@ class SVAnnotator:
             "FREQ_HET",
             "FREQ_HOMALT",
             "GRPMAX_AF",
+            "FILTER",
         ]
         gnomad_ann_cols = [
             "gnomAD_SVTYPE",
@@ -494,6 +495,7 @@ class SVAnnotator:
             "gnomAD_FREQ_HET",
             "gnomAD_FREQ_HOMALT",
             "gnomAD_GRPMAX_AF",
+            "gnomAD_FILTER"
         ]
         gnomad_df = pd.read_csv(gnomad, sep="\t", dtype="str").astype(str)
         gnomad_df.columns = gnomad_df.columns.str.replace("#", "")

--- a/scripts/crg.intersect_sv_vcfs.py
+++ b/scripts/crg.intersect_sv_vcfs.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from os import mkdir, path
+from os import mkdir, path, environ
 from shutil import move
 from pathlib import Path
 from datetime import date
@@ -228,6 +228,7 @@ def main(
 if __name__ == "__main__":
 
     report_dir = snakemake.output[0]
+    environ['TMPDIR'] = report_dir
     metasv = [vcf for vcf in snakemake.input if "metasv" in vcf]
     manta = [vcf for vcf in snakemake.input if "manta" in vcf]
 

--- a/scripts/crg.intersect_sv_vcfs.py
+++ b/scripts/crg.intersect_sv_vcfs.py
@@ -136,6 +136,7 @@ def main(
             "gnomAD_FREQ_HET",
             "gnomAD_FREQ_HOMALT",
             "gnomAD_GRPMAX_AF",
+            "gnomAD_FILTER",
             "DDD_disease",
             "DDD_mode",
             "DDD_pmids",

--- a/scripts/crg.intersect_sv_vcfs.py
+++ b/scripts/crg.intersect_sv_vcfs.py
@@ -135,7 +135,7 @@ def main(
             "gnomAD_FREQ_HOMREF",
             "gnomAD_FREQ_HET",
             "gnomAD_FREQ_HOMALT",
-            "gnomAD_POPMAX_AF",
+            "gnomAD_GRPMAX_AF",
             "DDD_disease",
             "DDD_mode",
             "DDD_pmids",
@@ -201,7 +201,7 @@ def main(
         "gnomAD_FREQ_HOMREF",
         "gnomAD_FREQ_HET",
         "gnomAD_FREQ_HOMALT",
-        "gnomAD_POPMAX_AF",
+        "gnomAD_GRPMAX_AF",
     ]
     non_numeric = [col for col in sv_records.df.columns if col not in numeric]
     for col in numeric:

--- a/scripts/process_gnomAD_v4_1_SV_bed.py
+++ b/scripts/process_gnomAD_v4_1_SV_bed.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+
+gnomad_df = pd.read_csv("/hpf/largeprojects/ccmbio/ajain/crg2_hg38/gnomad_v4.1/gnomad_SV/gnomad.v4.1.sv.sites.bed", sep="\t", dtype="str").astype(str)
+gnomad_df.columns = gnomad_df.columns.str.replace("#", "")
+gnomad_df.columns = gnomad_df.columns.str.strip()
+gnomad_df.rename({"chrom": "CHROM", "start": "START", "end": "END", "name": "NAME", "svtype": "SVTYPE", "samples": "SAMPLES" }, axis=1, inplace=True)
+gnomad_df["CHROM"] = gnomad_df["CHROM"].str.replace("chr", "")
+# in gnomAD v4.1 bed file, 'END' and 'SVTYPE' columns are duplicated
+gnomad_df = gnomad_df.loc[:, ~gnomad_df.columns.duplicated()]
+# select only columns of interest
+gnomad_cols = [
+    "CHROM",
+    "START",
+    "END",
+    "NAME",
+    "SVTYPE",
+    "AN",
+    "AC",
+    "AF",
+    "N_HOMREF",
+    "N_HET",
+    "N_HOMALT",
+    "FREQ_HOMREF",
+    "FREQ_HET",
+    "FREQ_HOMALT",
+    "GRPMAX_AF",
+    "FILTER",
+]
+gnomad_df = gnomad_df[gnomad_cols]
+gnomad_df.to_csv("/hpf/largeprojects/ccmbio/ajain/crg2_hg38/gnomad_v4.1/gnomad_SV/gnomad.v4.1.sv.sites.processed.bed", sep="\t", index=False )


### PR DESCRIPTION
Update gnomAD SV annotations to v4.1 (from https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/genome_sv/gnomad.v4.1.sv.sites.bed.gz). Note: The BED file has duplicated END and SVTYPE columns, which I remove prior to annotation against sample SVs in line 504 of `scripts/process_gnomAD_v4_1_SV_bed.py`.