### PR TITLE
Add ClinVar conflicting statuses

### DIFF
--- a/vcfanno/crg.vcfanno.conf
+++ b/vcfanno/crg.vcfanno.conf
@@ -54,9 +54,9 @@ ops=["concat"]
 
 [[annotation]]
 file="clinvar.vcf.gz"
-fields=["CLNSIG","CLNREVSTAT"]
-names=["clinvar_pathogenic", "clinvar_status"]
-ops=["concat", "concat"]
+fields=["CLNSIG","CLNREVSTAT", "CLNSIGCONF"]
+names=["clinvar_pathogenic", "clinvar_status", "clinvar_sig_conf"]
+ops=["concat", "concat", "concat"]
                     
 # convert 5 to 'pathogenic', 255 to 'unknown', etc.
 [[postannotation]]


### PR DESCRIPTION
Add details of ClinVar conflicting status using the CLNSIGCONF field in the ClinVar VCF. For example, instead of just annotating a variant as `Conflicting_classifications_of_pathogenicity` it would be annotated as `Conflicting_classifications_of_pathogenicity;Uncertain_significance(2)|Likely_benign(3)`. Associated with [cre PR #64](https://github.com/ccmbioinfo/cre/pull/64).