### PR TITLE
Update VEP to v113

### DIFF
--- a/config_cheo_ri.yaml
+++ b/config_cheo_ri.yaml
@@ -97,7 +97,7 @@ annotation:
     conf: "~/crg2/vcfanno/mt.vcfanno.conf"
     base_path: "/hpf/largeprojects/ccmbio/ajain/mity/vcfanno"
   vep:
-    dir: "/srv/shared/data/dccdipg/snakemake/6ea37454/share/ensembl-vep-101.0-0/"
+    dir: "/srv/shared/conda_envs/crg2-conda/b59ddfb3/share/ensembl-vep-113.3-0/"
     dir_cache: "/srv/shared/data/dccdipg/annotation/vep-cache"
   snpeff:
     dataDir: "/srv/shared/data/snpeff/"

--- a/config_hpf.yaml
+++ b/config_hpf.yaml
@@ -99,7 +99,7 @@ annotation:
     conf: "~/crg2/vcfanno/mt.vcfanno.conf"
     base_path: "/hpf/largeprojects/ccmbio/ajain/mity/vcfanno"
   vep:
-    dir: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/6f4af8a1/share/ensembl-vep-104.0-0/"
+    dir: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/9db6af70/share/ensembl-vep-113.3-1/"
     dir_cache: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/vep/"
   snpeff:
     dataDir: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/snpeff"

--- a/wrappers/vep/environment.yaml
+++ b/wrappers/vep/environment.yaml
@@ -1,5 +1,6 @@
 channels:
+  - conda-forge
   - bioconda
+  - defaults
 dependencies:
-  - ensembl-vep =104.0
-  - bcftools =1.9
+  - ensembl-vep =113.3

--- a/wrappers/vep/wrapper.py
+++ b/wrappers/vep/wrapper.py
@@ -42,7 +42,7 @@ log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 shell(
     "(vep --vcf -o stdout -i {incalls} {threadsprefix} --species homo_sapiens --no_stats --cache --offline {dirprefix} {dircacheprefix} --symbol --numbers --biotype --total_length "
-    "--canonical --gene_phenotype --ccds --uniprot --domains --regulatory --protein --tsl --appris --af --max_af --af_1kg --af_esp --af_gnomad "
+    "--canonical --gene_phenotype --ccds --uniprot --domains --regulatory --protein --tsl --appris --af --max_af --af_1kg --af_gnomad "
     "--pubmed --variant_class --allele_number {fastaprefix} "
     "--plugin SpliceRegion --sift b --polyphen b --hgvs --shift_hgvs 1 --merged  "
     "| sed '/^#/! s/;;/;/g' {outprefix} > {outcalls}) {log}"


### PR DESCRIPTION
Also downloaded the GRCh37 v113 annotation caches to the HPF (/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/vep/homo_sapiens_merged/113_GRCh37) and CHEO-RI (/srv/shared/data/dccdipg/annotation/vep-cache/homo_sapiens_merged/113_GRCh37/) spaces. Removed the `--af_esp` from the VEP wrapper as it's no longer a valid parameter.