### PR TITLE
Add clinvar conflicting status details for exome reports

### DIFF
--- a/vcfanno/cre.vcfanno.conf
+++ b/vcfanno/cre.vcfanno.conf
@@ -54,9 +54,9 @@ ops=["concat"]
 
 [[annotation]]
 file="clinvar.vcf.gz"
-fields=["CLNSIG","CLNREVSTAT"]
-names=["clinvar_pathogenic", "clinvar_status"]
-ops=["concat", "concat"]
+fields=["CLNSIG","CLNREVSTAT","CLNSIGCONF"]
+names=["clinvar_pathogenic", "clinvar_status","clinvar_sig_conf"]
+ops=["concat", "concat","concat"]
 
 # convert 5 to 'pathogenic', 255 to 'unknown', etc.
 [[postannotation]]


### PR DESCRIPTION
- Update the cre.vcfanno.conf file to add clinvar conflicting status details for exome reports