### PR TITLE
Update pathogenic disease thresholds in ExpansionHunter report 

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -26,7 +26,7 @@ elif config["run"]["pipeline"] == "wgs":
             expand("report/{p}/{family}", p=["panel", "panel-flank", "denovo"], family=project) if (config["run"]["hpo"] or config["run"]["panel"]) and config["run"]["ped"] else [],
             "report/coding/{family}".format(family=project),
             "report/sv",
-            expand("report/str/{family}.{report_name}.xlsx", family=project, report_name=["EH-v1.1","EHDN"]),
+            expand("report/str/{family}.{report_name}.xlsx", family=project, report_name=["EH-v1.1.2","EHDN"]),
             "qc/multiqc/multiqc.html",
             #"plots/depths.svg",
             #"plots/allele-freqs.svg"

--- a/config_cheo_ri.yaml
+++ b/config_cheo_ri.yaml
@@ -118,7 +118,7 @@ annotation:
     mssng_lumpy_counts: "/srv/shared/data/dccdipg/annotation/MSSNG_COUNTS/Canadian_MSSNG_parent_SVs.LUMPY.counts.txt"
   eh:
     catalog: "/srv/shared/data/dccdipg/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.hg19.masked.json"
-    trf: "/srv/shared/data/dccdipg/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.tsv"
+    trf: "/srv/shared/data/dccdipg/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.2.tsv"
     1000g: "/srv/shared/data/dccdipg/annotation/ExpansionHunter/1000G_EH_v1.0.tsv"
   ehdn:
     files: "/srv/shared/data/dccdipg/annotation/ExpansionHunterDenovo/"

--- a/config_hpf.yaml
+++ b/config_hpf.yaml
@@ -120,7 +120,7 @@ annotation:
     mssng_lumpy_counts: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/MSSNG_COUNTS/Canadian_MSSNG_parent_SVs.LUMPY.counts.txt"
   eh:
     catalog: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.hg19.masked.json"
-    trf: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.tsv"
+    trf: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.2.tsv"
     1000g: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/1000G_EH_v1.0.tsv"
   ehdn:
     files: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunterDenovo/"

--- a/rules/str.smk
+++ b/rules/str.smk
@@ -21,7 +21,7 @@ rule EH_report:
     output:
         tsv = "str/EH/{family}_EH_str.tsv",
         annot = "str/EH/{family}_EH_str.annot.tsv",
-        xlsx = "report/str/{family}.EH-v1.1.xlsx"
+        xlsx = "report/str/{family}.EH-v1.1.2.xlsx"
     log:
         "logs/str/{family}-eh-report.log"
     params:

--- a/scripts/str/eh_sample_report.py
+++ b/scripts/str/eh_sample_report.py
@@ -30,10 +30,7 @@ def outlier_gt(threshold, gt_dict):
             else:
                 if threshold == "":
                     continue
-                try:
-                    threshold = float(threshold)
-                except ValueError:
-                    threshold = int(threshold)
+                threshold = float(threshold)
                 if y >= float(threshold): 
                         outlier.append(sample)
 
@@ -88,7 +85,7 @@ worksheet.write_row(0, 0, header)
 row = 1
 for i in trf:
         info = trf[i][samples[0]]
-        content = [info.pos, info.motif, info.gene, info.size]
+        content = [info.pos, info.motif, info.gene, info.size.replace(".0", "")]
         content += [ trf[i][s].gt for s in samples ]          
         content += [info.mean, info.std, info.median] 
         gt = { s:trf[i][s].gt for s in samples }

--- a/scripts/str/eh_sample_report.py
+++ b/scripts/str/eh_sample_report.py
@@ -7,6 +7,7 @@ writes o/p as excel file
 '''
 
 import sys, os, re
+import numpy as np
 from collections import namedtuple
 from xlsxwriter.workbook import Workbook
 
@@ -17,8 +18,6 @@ xlsx = sys.argv[3] #output xlsx filename
 def outlier_gt(threshold, gt_dict):
     outlier = []
     for sample in gt_dict:
-        threshold = re.sub(u'\u2014','-',str(threshold))
-        #threshold = str(threshold.strip())
         x = gt_dict[sample]
         y = x.split("/") if "/" in x else x
         if not "." in y:
@@ -26,26 +25,19 @@ def outlier_gt(threshold, gt_dict):
         else:
             return " "
         if y:
-            if "(" in threshold or " " in threshold:
-                continue
-            elif ">" in threshold:
-                if "-" in threshold:
-                    condition = int(threshold.split(">")[1].split("-")[0])
-                else:
-                    condition = int(threshold.split(">")[1])
-                    if y >= condition:
-                        outlier.append(sample)
-            elif "-" in threshold:
-                condition = list(map(int, threshold.split("-")))
-                if y in range(condition[0], condition[1]):
-                    outlier.append(sample)
-            elif "," in threshold:
-                condition = list(map(int, threshold.split(",")))
-                if y in condition:
-                    outlier.append(sample)
+            if threshold == np.nan: 
+                return " "
             else:
-                if threshold.isdigit() and y >= int(threshold):
-                    outlier.append(sample)    
+                if threshold == "":
+                    continue
+                try:
+                    threshold = float(threshold)
+                except ValueError:
+                    threshold = int(threshold)
+                if y >= float(threshold): 
+                        outlier.append(sample)
+
+ 
     return ",".join(outlier) if outlier else ' '
     
 


### PR DESCRIPTION
I compared the disease thresholds being used in our pipeline (derived from this [spreadsheet](https://docs.google.com/spreadsheets/d/1Z2ckjXid2yNqdPNYPCU8LadiQY4T8sxiE3KaiHrDcOk/edit?gid=0#gid=0)) to the pathogenic minima in [STRchive](https://strchive.org/) as listed in the hg19 BED file under the Resources tab. The Jupyter Notebook can be found at /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/update_thresholds.ipynb.

Where the threshold differed between STRchive and our pipeline, I used the value reported by STRchive. The new reference file is at /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.2.tsv. I updated `scripts/str/eh_sample_report.py` to use the pathogenic minima rather than the custom text parsing used previously. 