### PR TITLE
bug fix in rule pass

### DIFF
--- a/rules/annotation.smk
+++ b/rules/annotation.smk
@@ -26,7 +26,8 @@ rule pass:
     threads: 6
     resources:
         mem=lambda wildcards, threads: threads * 2
-    params: "-f PASS"
+    params: 
+        filter = "-f PASS"
     wrapper:
         get_wrapper_path("bcftools", "view")
 


### PR DESCRIPTION
**Bug description:** For genomes, there was a bug in the rule pass (rules/annotation.smk) because of which non-PASS variants were being retained in the VCF files.

**Fix:** Modified the params in rule pass.

**Testing:** Tested on one family (F396)
- No. of records in VCF (before bug-fix) = 4745987
- No. of records in VCF (after bug-fix) = 4702588