### PR TITLE
Automate monthly ClinVar download 

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -1,10 +1,14 @@
 # Helpful scripts related to exome/genome processing
 
-1. ```bam_slice_crg2.sh```: create a bam slice for a particular genomic region including specified flank.
-2. ```check_dup_rate```: check duplication rate for each member of a family.
-3. ```copy_reports_to_minio_bcbio.sh```: copy reports from bcbio runs to MinIO. Must be run as ccmmarvin.
-4. ```copy_reports_to_minio_DeepExomeSeq.sh```: copy reports from deep exome sequencing runs to MinIO. Must be run as ccmmarvin.
-5. ```copy_reports_to_minio.sh```: copy reports from crg2 runs to MinIO. Must be run as ccmmarvin.
-6. ```gen_sample_sheet.py```: generate a sample sheet for a batch of genomes downloaded from TCAG for input to crg2/parser_genomes.py.
-7. ```mv2results.py```: move exome or genome analysis folders to results directory.
-8. ```wgs_gene_coverage/get_gene_coverage.sh```: generate wgs cram coverage report across exons/introns for given gene using mosdepth.
+1. ```bam_slice_by_gene.py```: Extract a BAM file slice for a specific gene region or coordinates with configurable flanking sequence (source: https://github.com/naumenko-sa/bioscripts).
+2. ```bam.coverage.base_wise.stat.py```: Calculate base-wise coverage stats for a BAM file (source: https://github.com/naumenko-sa/bioscripts). 
+3. ```bam.coverage.less20.sh```: Report how many bases are below 20X coverage per exon in a BAM file (source: https://github.com/naumenko-sa/bioscripts).
+4. ```bam.coverage.per_exon.sh```: Reports the distribution of lowest coverage in exons from a BAM file: (source: https://github.com/naumenko-sa/bioscripts).
+5. ```check_dup_rate```: Calculate and report PCR duplication rates for all samples in a family.
+6. ```copy_reports_to_minio_bcbio.sh```: Transfer bcbio pipeline analysis reports to MinIO storage (requires ccmmarvin credentials).
+7. ```copy_reports_to_minio_DeepExomeSeq.sh```: Transfer deep exome sequencing reports to MinIO storage (requires ccmmarvin credentials).
+8. ```copy_reports_to_minio.sh```: Transfer crg2 pipeline reports to MinIO storage (requires ccmmarvin credentials).
+9. ```download_clinvar.sh```: Download and update ClinVar VCF files for both GRCh37 and GRCh38 genome builds. Add `0 0 15 * * sh ~/crg2/utils/download_clinvar.sh` to your crontab (`crontab -e`) to update ClinVar on the 15th of every month. 
+10. ```gen_sample_sheet.py```: Create a sample sheet from TCAG genome data for use with crg2/parser_genomes.py.
+11. ```mv2results.py```: Organize and move completed exome/genome analysis folders to the results directory.
+12. ```wgs_gene_coverage/get_gene_coverage.sh```: Generate detailed coverage metrics for exons and introns of specified genes using mosdepth on WGS CRAM files.

--- a/utils/download_clinvar.sh
+++ b/utils/download_clinvar.sh
@@ -2,9 +2,21 @@
 # to run this script automatically on a monthly basis, add the following line to your crontab using `crontab -e`:
 # 0 0 15 * * sh ~/crg2/utils/download_clinvar.sh
 set -e
+server=$1
 DATE=`date +%Y-%m-%d`
-DIR_HG19=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/
-DIR_HG38=/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/
+
+if [ -z "$server" ]; then
+    echo "Usage: $0 <server>"
+    echo "server: hpf or g4rd"
+    exit 1
+fi
+
+if [ "$server" == "hpf" ]; then
+    DIR_HG19=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/
+    DIR_HG38=/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/
+elif [ "$server" == "g4rd" ]; then
+    DIR_HG19=/srv/shared/data/dccdipg/annotation/vcfanno/
+fi
 
 # hg19
 mv ${DIR_HG19}/clinvar.vcf.gz ${DIR_HG19}/clinvar_old/clinvar.${DATE}.vcf.gz
@@ -18,13 +30,14 @@ echo -e "${md5}\t${DIR_HG19}/clinvar.vcf.gz" > ${DIR_HG19}/clinvar.vcf.gz.md5
 md5sum -c ${DIR_HG19}/clinvar.vcf.gz.md5
 
 # hg38
-mv ${DIR_HG38}/clinvar.vcf.gz ${DIR_HG38}/clinvar_old/clinvar.${DATE}.vcf.gz
-rm ${DIR_HG38}/clinvar.vcf.gz.tbi ${DIR_HG38}/clinvar.vcf.gz.md5
+if [ "$server" == "hpf" ]; then
+    mv ${DIR_HG38}/clinvar.vcf.gz ${DIR_HG38}/clinvar_old/clinvar.${DATE}.vcf.gz
+    rm ${DIR_HG38}/clinvar.vcf.gz.tbi ${DIR_HG38}/clinvar.vcf.gz.md5
 
-wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz -O ${DIR_HG38}/clinvar.vcf.gz
-wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.tbi -O ${DIR_HG38}/clinvar.vcf.gz.tbi
-wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.md5 -O ${DIR_HG38}/clinvar.vcf.gz.md5
-md5=`awk '{print $1}'  ${DIR_HG38}/clinvar.vcf.gz.md5`
-echo -e "${md5}\t${DIR_HG38}/clinvar.vcf.gz" > ${DIR_HG38}/clinvar.vcf.gz.md5
-md5sum -c ${DIR_HG38}/clinvar.vcf.gz.md5
-
+    wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz -O ${DIR_HG38}/clinvar.vcf.gz
+    wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.tbi -O ${DIR_HG38}/clinvar.vcf.gz.tbi
+    wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.md5 -O ${DIR_HG38}/clinvar.vcf.gz.md5
+    md5=`awk '{print $1}'  ${DIR_HG38}/clinvar.vcf.gz.md5`
+    echo -e "${md5}\t${DIR_HG38}/clinvar.vcf.gz" > ${DIR_HG38}/clinvar.vcf.gz.md5
+    md5sum -c ${DIR_HG38}/clinvar.vcf.gz.md5
+fi

--- a/utils/download_clinvar.sh
+++ b/utils/download_clinvar.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # to run this script automatically on a monthly basis, add the following line to your crontab using `crontab -e`:
 # 0 0 15 * * sh ~/crg2/utils/download_clinvar.sh
+set -e
 DATE=`date +%Y-%m-%d`
 DIR_HG19=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/
 DIR_HG38=/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/
@@ -9,17 +10,21 @@ DIR_HG38=/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/
 mv ${DIR_HG19}/clinvar.vcf.gz ${DIR_HG19}/clinvar_old/clinvar.${DATE}.vcf.gz
 rm ${DIR_HG19}/clinvar.vcf.gz.tbi ${DIR_HG19}/clinvar.vcf.gz.md5
 
-wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz > ${DIR_HG19}/clinvar.vcf.gz
-wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz.tbi > ${DIR_HG19}/clinvar.vcf.gz.tbi
-wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz.md5 > ${DIR_HG19}/clinvar.vcf.gz.md5
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz -O ${DIR_HG19}/clinvar.vcf.gz
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz.tbi -O ${DIR_HG19}/clinvar.vcf.gz.tbi
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz.md5 -O ${DIR_HG19}/clinvar.vcf.gz.md5
+md5=`awk '{print $1}'  ${DIR_HG19}/clinvar.vcf.gz.md5`
+echo -e "${md5}\t${DIR_HG19}/clinvar.vcf.gz" > ${DIR_HG19}/clinvar.vcf.gz.md5
 md5sum -c ${DIR_HG19}/clinvar.vcf.gz.md5
 
 # hg38
 mv ${DIR_HG38}/clinvar.vcf.gz ${DIR_HG38}/clinvar_old/clinvar.${DATE}.vcf.gz
 rm ${DIR_HG38}/clinvar.vcf.gz.tbi ${DIR_HG38}/clinvar.vcf.gz.md5
 
-wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz > ${DIR_HG38}/clinvar.vcf.gz
-wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.tbi > ${DIR_HG38}/clinvar.vcf.gz.tbi
-wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.md5 > ${DIR_HG38}/clinvar.vcf.gz.md5
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz -O ${DIR_HG38}/clinvar.vcf.gz
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.tbi -O ${DIR_HG38}/clinvar.vcf.gz.tbi
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.md5 -O ${DIR_HG38}/clinvar.vcf.gz.md5
+md5=`awk '{print $1}'  ${DIR_HG38}/clinvar.vcf.gz.md5`
+echo -e "${md5}\t${DIR_HG38}/clinvar.vcf.gz" > ${DIR_HG38}/clinvar.vcf.gz.md5
 md5sum -c ${DIR_HG38}/clinvar.vcf.gz.md5
 

--- a/utils/download_clinvar.sh
+++ b/utils/download_clinvar.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# to run this script automatically on a monthly basis, add the following line to your crontab using `crontab -e`:
+# 0 0 15 * * sh ~/crg2/utils/download_clinvar.sh
+DATE=`date +%Y-%m-%d`
+DIR_HG19=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/
+DIR_HG38=/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/
+
+# hg19
+mv ${DIR_HG19}/clinvar.vcf.gz ${DIR_HG19}/clinvar_old/clinvar.${DATE}.vcf.gz
+rm ${DIR_HG19}/clinvar.vcf.gz.tbi ${DIR_HG19}/clinvar.vcf.gz.md5
+
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz > ${DIR_HG19}/clinvar.vcf.gz
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz.tbi > ${DIR_HG19}/clinvar.vcf.gz.tbi
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz.md5 > ${DIR_HG19}/clinvar.vcf.gz.md5
+md5sum -c ${DIR_HG19}/clinvar.vcf.gz.md5
+
+# hg38
+mv ${DIR_HG38}/clinvar.vcf.gz ${DIR_HG38}/clinvar_old/clinvar.${DATE}.vcf.gz
+rm ${DIR_HG38}/clinvar.vcf.gz.tbi ${DIR_HG38}/clinvar.vcf.gz.md5
+
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz > ${DIR_HG38}/clinvar.vcf.gz
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.tbi > ${DIR_HG38}/clinvar.vcf.gz.tbi
+wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.md5 > ${DIR_HG38}/clinvar.vcf.gz.md5
+md5sum -c ${DIR_HG38}/clinvar.vcf.gz.md5
+


### PR DESCRIPTION
This script downloads hg19 and hg38 ClinVar VCFs, indices, and md5 files. It is compatible with both the hpf and G4RD/CHEO-RI servers. It also checks the md5sums of the downloaded VCFs.  Add `0 0 15 * * sh ~/crg2/utils/download_clinvar.sh` to your crontab (`crontab -e`) to update ClinVar on the 15th of every month. 
