### PR TITLE
Update C4R WGS counts

### DIFF
--- a/vcfanno/crg.vcfanno.conf
+++ b/vcfanno/crg.vcfanno.conf
@@ -142,7 +142,7 @@ ops=["concat"]
 
 #C4R WGS counts and samples
 [[annotation]]
-file="seen_in_c4r-genomes-20211110.tsv.gz"
+file="C4R_genomes_with_AC_samples_capped.tsv.gz"
 columns = [5,6]
 names = ["c4r_wgs_samples", "c4r_wgs_counts"]
 ops=["first", "first"]


### PR DESCRIPTION
- Scripts to generate the C4R genome TSV are located at /srv/shared/hpf/short_read_genomes/code/genome_db. 
- CHEO-RI TSV: /srv/shared/data/dccdipg/annotation/vcfanno/C4R_genomes_with_AC_samples_capped.tsv.gz.
- HPF TSV: /hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation/C4R_genomes_with_AC_samples_capped.tsv.gz