### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,22 @@ crg2 uses Snakemake and Conda to manage jobs and software dependencies.
 
 A note about the config files: the values in config_hpf.yaml refer to tool/filepaths on SickKid's HPC4Health tenancy (hpf), while the values in config_cheo_ri.yaml refer to tool/filepaths on CHEO's HPC4Health tenancy. For simplicity, we refer below only to config_hpf.yaml; if you are running crg2 on CHEO's tenancy, use config_cheo_ri.yaml instead. 
 
-1. If you are running crg2 on the hpf, skip to the 'Running the pipeline' section.
-2. Download and setup Anaconda: https://docs.conda.io/projects/conda/en/latest/user-guide/install/linux.html
-3. Install Snakemake 5.10.0 via Conda: https://snakemake.readthedocs.io/en/stable/getting_started/installation.html
-4. Git clone this repo, [crg](https://github.com/ccmbioinfo/crg), and [cre](https://github.com/ccmbioinfo/cre). crg2 uses various scripts from other two repos to generate final reports.
-5. Make a directory for Conda to install all its environments and executables in, for example:
+### Running crg2 on the hpf
+
+1. Git clone this repo, [crg](https://github.com/ccmbioinfo/crg), and [cre](https://github.com/ccmbioinfo/cre) into your home directory on the hpf. crg2 uses various scripts from the other two repos to generate final reports.
+2. Skip to the "Running the pipeline" section.
+
+### Running crg2 in another location
+
+1. Download and setup Anaconda: https://docs.conda.io/projects/conda/en/latest/user-guide/install/linux.html
+2. Install Snakemake 5.10.0 via Conda: https://snakemake.readthedocs.io/en/stable/getting_started/installation.html
+3. Git clone this repo, [crg](https://github.com/ccmbioinfo/crg), and [cre](https://github.com/ccmbioinfo/cre). crg2 uses various scripts from the other two repos to generate final reports.
+4. Make a directory for Conda to install all its environments and executables in, for example:
 ```
 mkdir ~/crg2-conda
 ```
 
-6. Navigate to the crg2 directory. Install all software dependencies using:
+5. Navigate to the crg2 directory. Install all software dependencies using:
 - WGS:
   ```
   cd crg2
@@ -36,13 +42,13 @@ mkdir ~/crg2-conda
   ```
 Make sure to replace ```~/crg2-conda``` with the path made in step 4. This will take a while.
 
-7. Install these plugins for VEP: ```LoF, MaxEntScan, SpliceRegion```. Refer to this page for installation instructions: https://useast.ensembl.org/info/docs/tools/vep/script/vep_plugins.html. The INSTALL.pl script has been renamed to vep_install in the VEP's Conda build. It is located in the conda environment directory, under ```share/ensembl-vep-99.2-0/vep_install```. Therefore, your command should be similar to: ```fb5f2eb3/share/ensembl-vep-99.2-0/vep_install -a p --PLUGINS LoF,MaxEntScan,SpliceRegion```
+6. Install these plugins for VEP: ```LoF, MaxEntScan, SpliceRegion```. Refer to this page for installation instructions: https://useast.ensembl.org/info/docs/tools/vep/script/vep_plugins.html. The INSTALL.pl script has been renamed to vep_install in the VEP's Conda build. It is located in the conda environment directory, under ```share/ensembl-vep-99.2-0/vep_install```. Therefore, your command should be similar to: ```fb5f2eb3/share/ensembl-vep-99.2-0/vep_install -a p --PLUGINS LoF,MaxEntScan,SpliceRegion```
 
-8. Git clone cre: ```git clone https://github.com/ccmbioinfo/cre``` to a safe place.
+7. Git clone cre: ```git clone https://github.com/ccmbioinfo/cre``` to a safe place.
 
-9. Replace the VEP paths to the VEP directory installed from step 6. Replace the cre path in crg2/config_hpf.yaml with the one from step 7.
+8. Replace the VEP paths to the VEP directory installed from step 6. Replace the cre path in crg2/config_hpf.yaml with the one from step 7.
 
-10. AnnotSV 2.1 is required for SV report generation.
+9. AnnotSV 2.1 is required for SV report generation.
 - Download AnnotSV:  ```wget https://lbgi.fr/AnnotSV/Sources/AnnotSV_2.1.tar.gz```
 - Unpack : ```tar -xzvf AnnotSV_2.1.tar.gz```
 - Set the value of $ANNOTSV in your .bashrc: ```export ANNOTSV=/path_of_AnnotSV_installation/bin```
@@ -52,7 +58,7 @@ Make sure to replace ```~/crg2-conda``` with the path made in step 4. This will 
   - set ```-reciprocal             yes```
   - set ```-svtBEDcol:     4```
 
-11. To generate a gene panel from an HPO text file exported from PhenomeCentral or G4RD, add the HPO filepath to `config["run"]["hpo"]`. You will also need to generate Ensembl and RefSeq gene files as well as an HGNC gene mapping file.
+10. To generate a gene panel from an HPO text file exported from PhenomeCentral or G4RD, add the HPO filepath to `config["run"]["hpo"]`. You will also need to generate Ensembl and RefSeq gene files as well as an HGNC gene mapping file.
 - Download and unzip Ensembl gtf: ```wget -qO- http://ftp.ensembl.org/pub/grch37/current/gtf/homo_sapiens/Homo_sapiens.GRCh37.87.gtf.gz  | gunzip -c > Homo_sapiens.GRCh37.87.gtf```
 - Download and unzip RefSeq gff: ```wget https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh37_latest/refseq_identifiers/GRCh37_latest_genomic.gff.gz | gunzip -c > GRCh37_latest_genomic.gff```
 - Download RefSeq chromosome mapping file: ```wget https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh37_latest/refseq_identifiers/GRCh37_latest_assembly_report.txt```
@@ -60,7 +66,7 @@ Make sure to replace ```~/crg2-conda``` with the path made in step 4. This will 
 - Add the paths to the output files, Homo_sapiens.GRCh37.87.gtf_subset.csv and GRCh37_latest_genomic.gff_subset.csv, to the `config["gene"]["ensembl"]` and `config["gene"]["refseq"]` fields.
 - You will also need the HGNC alias file: download this from https://www.genenames.org/download/custom/ using the default fields. Add the path this file to `config["gene"]["hgnc"]`.
 
-12. crg2 uses [mity](https://github.com/KCCG/mity) to call and annotate small mitochondrial variants. Mity is not available via conda unfortunately, so it must be installed manually into an environment. The first time you run crg2 WGS, snakemake will build the conda environments specified in wrappers/mity/*/environment.yaml, which include the dependencies necessary to run mity. You can find the conda environment associated with rule `mity_call` by looking at the slurm log file for that rule after the pipeline tries and fails to run mity. Activate this environment, then manually install mity into this conda environment: 
+11. crg2 uses [mity](https://github.com/KCCG/mity) to call and annotate small mitochondrial variants. Mity is not available via conda unfortunately, so it must be installed manually into an environment. The first time you run crg2 WGS, snakemake will build the conda environments specified in wrappers/mity/*/environment.yaml, which include the dependencies necessary to run mity. You can find the conda environment associated with rule `mity_call` by looking at the slurm log file for that rule after the pipeline tries and fails to run mity. Activate this environment, then manually install mity into this conda environment: 
 ```pip install mitywgs==0.4.0```
 Replace `config["tools"]["mity"]` with the path to the conda environment binaries, e.g. "/srv/shared/conda_envs/crg2-conda/8a9bda62/bin/". You may also need to add a shebang at the top of the mity program (in this example, /srv/shared/conda_envs/crg2-conda/8a9bda62/bin/mity): 
 ```#!/srv/shared/conda_envs/crg2-conda/8a9bda62/bin/python3```
@@ -216,18 +222,10 @@ run:
 ...
 ```
 
-3. Activate the conda environment with Snakemake 5.10.0
+3. Test that the pipeline will run by adding the flag "-n" to the snakemake command in dnaseq_slurm_hpf.sh and running that script.
 
 ```
-(base) [dennis.kao@qlogin5 crg2]$ conda activate snakemake
-(snakemake) [dennis.kao@qlogin5 crg2]$ snakemake -v
-5.10.0
-```
-
-4. Test that the pipeline will run by adding the flag "-n" to the command in dnaseq_slurm_hpf.sh and running it.
-
-```
-(snakemake) [dennis.kao@qlogin5 crg2]$ sh dnaseq_slurm_hpf.sh
+(base) [dennis.kao@qlogin5 crg2]$ ./dnaseq_slurm_hpf.sh
 Building DAG of jobs...
 Job counts:
 	count	jobs
@@ -290,7 +288,7 @@ This was a dry-run (flag -n). The order of jobs does not reflect the order of ex
 ...
 ```
 
-5. Submit pipeline job to the cluster
+4. Submit pipeline job to the cluster
 
     Job scheduler: PBS on SickKids hpf
       * Serialized jobs:

--- a/README.md
+++ b/README.md
@@ -290,14 +290,6 @@ This was a dry-run (flag -n). The order of jobs does not reflect the order of ex
 
 4. Submit pipeline job to the cluster
 
-    Job scheduler: PBS on SickKids hpf
-      * Serialized jobs:
-      ```qsub dnaseq.pbs```
-      * Parallelized jobs:
-       ```qsub dnaseq_cluster.pbs```
-
-    Refer to `pbs_profile/cluster.md` document for detailed documentation for cluster integration.
-
     Job scheduler: Slurm
       * Parallelized jobs on SickKids hpf:
       ```sbatch dnaseq_slurm_hpf.sh```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Clinical research pipeline for exploring variants in whole genome (WGS) and exom
 </div>
 
 crg2 is a research pipeline aimed at discovering clinically relevant variants in whole genome and exome sequencing data.
-It aims to provide reproducible results, be computationally efficient, and transparent in it's workflow.
+It aims to provide reproducible results, be computationally efficient, and transparent in its workflow.
 
 crg2 uses Snakemake and Conda to manage jobs and software dependencies.
 
@@ -88,9 +88,9 @@ Replace `config["tools"]["mity"]` with the path to the conda environment binarie
 4. Remove reads mapped to decoy chromosomes
 
 ### WGS: SNV
-1. Call SNV's and generate gVCFs
+1. Call SNVs and generate gVCFs
 
-2. Merge gVCF's and perform joint genotyping
+2. Merge gVCFs and perform joint genotyping
 
 3. Filter against GATK best practices filters
 
@@ -120,7 +120,7 @@ Replace `config["tools"]["mity"]` with the path to the conda environment binarie
 8. Repeat the above 1-7 steps using GATK MUTECT2 variant calls to generate a mosaic variant report
 
 ### WGS: SV (filtered and unfiltered)
-1. Call SV's using Manta, Smoove and Wham
+1. Call SVs using Manta, Smoove and Wham
 
 2. Merge calls using MetaSV
 
@@ -143,7 +143,7 @@ Replace `config["tools"]["mity"]` with the path to the conda environment binarie
 A. ExpansionHunter: known repeat location
 
   1. Identify repeat expansions in sample BAM/CRAMs
-  2. Annotate repeats with disease threshold, gene name, repeat sizes from 1000Genome (mean& median) 
+  2. Annotate repeats with disease threshold, gene name, repeat sizes from 1000Genome (mean & median) 
   3. Generate per-family report as Excel file
 
 B. ExpansionHunterDenovo: denovo repeats
@@ -179,10 +179,10 @@ cd NA12878
 ```
 
 2. Set up pipeline run 
-  * Reconfigure 'samples.tsv', 'units.tsv' to reflect sample names and input files.
+  * Reconfigure 'samples.tsv' and 'units.tsv' to reflect sample names and input files.
   * Modify 'config_hpf.yaml': 
     * change `project` to refer to the family ID (here, NA12878).
-    * set `pipeline` to `wes`, `wgs`, `annot` or `mity` for exome sequences, whole genome sequences, to simply annotate a VCF respectively or to generate mitochondrial reports
+    * set `pipeline` to `wes`, `wgs`, `annot` or `mity` for exome sequences, whole genome sequences, to simply annotate a VCF, or to generate mitochondrial reports, respectively
     * inclusion of a panel bed file (`panel`) or hpofile (`hpo`) will generate 2 SNV reports with all variants falling within these regions, one which includes variants in flanking regions as specified by `flank`.
     * inclusion of a `ped` file with parents and a proband(s) will allow generation of a genome-wide de novo report if `pipeline` is `wgs`.
     * `minio` refers to the path of the file system mount that backs MinIO in the CHEO HPC4Health tenancy. Exome reports (and coverage reports, if duplication percentage is >20%) will be copied to this path if specified. 


### PR DESCRIPTION
Suggested README changes based on my experience with the onboarding process:
- clarifying additional setup steps necessary even when preparing to run the pipeline in the hpf
- removing a mention of the pre-slurm job scheduler and cleaning up some minor grammar/typos