### PR TITLE
Add WES support to the hg38 branch

### DIFF
--- a/dnaseq_slurm_hpf.sh
+++ b/dnaseq_slurm_hpf.sh
@@ -10,6 +10,8 @@ CP="/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake"
 SLURM=~/crg2/slurm_profile/
 CONFIG=config_hpf.yaml
 
+module purge
+
 source /hpf/largeprojects/ccm_dccforge/dccdipg/Common/anaconda3/etc/profile.d/conda.sh
 conda activate snakemake
 

--- a/hg38/config_hpf.yaml
+++ b/hg38/config_hpf.yaml
@@ -35,6 +35,7 @@ ref:
   split_genome: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/split_genome"
   dragstr_table: "/hpf/largeprojects/ccmbio/nhanafi/c4r/genomes/illumina/hg38.str.zip"
   gatk-known: "/hpf/largeprojects/ccmbio/nhanafi/c4r/genomes/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+  ref_cache: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/REF_CACHE/GRCh37d5/%2s/%2s/%s:/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/REF_CACHE/hg19/%2s/%2s/%s:/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/REF_CACHE/GRCh37/%2s/%2s/%s"
   old_cram_ref: "UR:/mnt/hnas/reference/hg19/hg19.fa"
   new_cram_ref: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/hg19/seq/hg19.fa"
   bed_index: "/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/seq/GRCh37.fa.bedtoolsindex"

--- a/hg38/config_hpf.yaml
+++ b/hg38/config_hpf.yaml
@@ -13,7 +13,7 @@ run:
 
 genes:
   ensembl: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/ensembl_genes_hg38_gtf.csv"
-  refseq: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/GRCh37_latest_genomic.gff_subset.csv" 
+  refseq: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/GRCh38_latest_genomic.gff_subset.csv" 
   hgnc: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/HGNC_20210617.txt"
 
 tools:
@@ -30,7 +30,6 @@ ref:
   genome: /hpf/largeprojects/ccmbio/nhanafi/c4r/genomes/GIAB/GCA_000001405.15_GRCh38_no_alt_analysis_set_maskedGRC_exclusions_v2.fasta
   known-variants: /hpf/largeprojects/ccmbio/nhanafi/c4r/genomes/Homo_sapiens_assembly38.dbsnp138.vcf
   no_decoy: /hpf/largeprojects/ccmbio/nhanafi/c4r/genomes/GIAB/GCA_000001405.15_GRCh38_no_alt_analysis_set_maskedGRC_exclusions_v2_EBV_removed.fasta
-  decoy_bed: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/pipelines/cre/data/grch37d5.decoy.bed"
   canon_bed: "/hpf/largeprojects/ccmbio/nhanafi/c4r/genomes/illumina/grch38_canon.bed"
   split_genome: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/genomes/split_genome"
   dragstr_table: "/hpf/largeprojects/ccmbio/nhanafi/c4r/genomes/illumina/hg38.str.zip"

--- a/hg38/config_hpf.yaml
+++ b/hg38/config_hpf.yaml
@@ -136,6 +136,9 @@ params:
     #BaseRecalibrator: "--interval-set-rule INTERSECTION -U LENIENT-VCF-PROCESSING --read-filter BadCigar --read-filter NotzPrimaryAlignment"
     GenotypeGVCFs: ""
     VariantRecalibrator: ""
+    Mutect2:
+      gnomad_germline: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/Mutect2/af-only-gnomad.hg38.vcf.gz"
+    FilterMutectCalls: ""
   gatk3:
     java_opts: "-Xms500m -Xmx9555m"
     HaplotypeCaller: "-drf DuplicateRead --interval_set_rule INTERSECTION --pair_hmm_implementation VECTOR_LOGLESS_CACHING -ploidy 2 -U LENIENT_VCF_PROCESSING --read_filter BadCigar --read_filter NotPrimaryAlignment"
@@ -172,11 +175,16 @@ params:
   bcftools:
     mpileup: "-a DP -a AD "
     call: " -m -v "
-  freebayes: " --genotype-qualities --strict-vcf --ploidy 2 --no-partial-observations --min-repeat-entropy 1 "
+    # -F x sets the output filter to PASS if any of the variant filters is PASS in sample VCFs to be merged
+    merge: "-F x"
+  freebayes:
+    call: " --genotype-qualities --strict-vcf --ploidy 2 --no-partial-observations --min-repeat-entropy 1 "
   platypus: "--filterDuplicates=0"
   rtg-tools:
     java_opts: "-Xmx20g"
     vcfeval:
       sdf: "/hpf/largeprojects/ccmbio/nhanafi/c4r/genomes/GIAB/hg38_SD"
+    vcfsubset:
+      java_opts: "-Xmx2048m"
   peddy:
     sites: "--sites hg38"

--- a/hg38/config_hpf.yaml
+++ b/hg38/config_hpf.yaml
@@ -154,11 +154,11 @@ params:
     AssumeSortOrder: "ASSUME_SORT_ORDER=coordinate"
     java_opts: "-Xmx2g"
   qualimap:
-    mem: "20G"
+    mem: "60G"
     nw: 400
     c: "-c"
     hm: 3
-    gtf: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/hg38_exons_from_biomart_20220802_placeholder_nochr.txt"
+    gtf: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/hg38_exons_from_biomart_20220802_placeholder_wchr.txt"
     extra: ""
   verifybamid2:
     svd_prefix: "1000g.phase3 100k b38"

--- a/hg38/config_hpf.yaml
+++ b/hg38/config_hpf.yaml
@@ -179,4 +179,5 @@ params:
     java_opts: "-Xmx20g"
     vcfeval:
       sdf: "/hpf/largeprojects/ccmbio/nhanafi/c4r/genomes/GIAB/hg38_SD"
-
+  peddy:
+    sites: "--sites hg38"

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -5,6 +5,7 @@ rule input_prep:
     params:
         outdir = temp("fastq/"),
         sort_check = True,
+        ref_cache = config["ref"]["ref_cache"],
         old_cram_ref = config["ref"]["old_cram_ref"],
         new_cram_ref = config["ref"]["new_cram_ref"]
     output:

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -120,7 +120,7 @@ rule peddy:
         "qc/peddy/{family}.sex_check.csv",
         "qc/peddy/{family}.background_pca.json"
     params:
-        "-p 7"
+        f"-p 7 {config['params']['peddy']['sites']}"
     log:
         "logs/peddy/{family}.log"
     wrapper:

--- a/scripts/BTlib.py
+++ b/scripts/BTlib.py
@@ -140,7 +140,7 @@ def get_repeat_features_extended_segments(repeat_filename, CNV_chr, CNV_start, C
     CNV_end = int(CNV_end)
     CNV_size = CNV_end - CNV_start + 1
 
-    chr_size = get_hg19_chromosome_sizes()
+    chr_size = get_hg38_chromosome_sizes()
 
     extend_size = CNV_size * extend_proportion
 

--- a/slurm_profile/slurm-config.yaml
+++ b/slurm_profile/slurm-config.yaml
@@ -30,7 +30,8 @@ snpeff:
   mem: "25G"
 
 qualimap:
-  mem: "30G"
+  mem: "60G"
+  time: "100:00:00"
 
 allsnvreport:
   mem: "60G"

--- a/vcfanno/cre.vcfanno_hg38.conf
+++ b/vcfanno/cre.vcfanno_hg38.conf
@@ -1,16 +1,9 @@
-#gnomad exomes v.2.1.1 (lifted over)
+#gnomad v.4.1.0 merged joint frequency (hg38)
 [[annotation]]
-file="gnomad_exome.2.1.1_LIFTOVER.vcf.gz"
-fields=["AC","nhomalt","AF_popmax","AN","AC_male"]
-names=["gnomad_ac_es","gnomad_hom_es","gnomad_af_es","gnomad_an_es","gnomad_male_ac_es"]
-ops=["first","first","first","first","first"]
-
-#gnomad genomes v.3.1.2 (native hg38)
-[[annotation]]
-file="gnomad_genomes_v.3.1.2.vcf.gz"
-fields=["AC", "nhomalt","AF_popmax","AN","AC_XY"]
-names=["gnomad_ac_gs", "gnomad_hom_gs","gnomad_af_gs","gnomad_an_gs","gnomad_male_ac_gs"]
-ops=["self","self","self","self","self"]
+file="gnomad_merged_joint_frequencies_v4.1.0.vcf.gz"
+fields=["AC_joint", "nhomalt_joint","AF_joint","AF_grpmax_joint","AN_joint","AC_joint_XY","fafmax_faf95_max_joint","FILTER"]
+names=["gnomad_ac", "gnomad_hom","gnomad_af","gnomad_af_grpmax","gnomad_an","gnomad_male_ac","gnomad_fafmax_faf95_max","gnomad_filter"]
+ops=["self","self","self","self","self","self","self","self"]
 
 [[postannotation]]
 fields=["gnomad_ac_es","gnomad_ac_gs"]

--- a/wrappers/platypus/wrapper.py
+++ b/wrappers/platypus/wrapper.py
@@ -5,6 +5,7 @@ __license__ = "MIT"
 
 
 import os
+import re
 
 from snakemake.shell import shell
 
@@ -26,7 +27,7 @@ params = snakemake.params if snakemake.params else ""
 
 # need sequence dictionary for picard sort
 # sometimes Platypus VCFs are not properly sorted , even after vcfstreamsort
-seq_dict = snakemake.input.ref.replace(".fa", ".dict")
+seq_dict = re.sub(r"\.fa(sta)?$", ".dict", snakemake.input.ref)
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 

--- a/wrappers/report_upload/post_report/PTQuery.py
+++ b/wrappers/report_upload/post_report/PTQuery.py
@@ -159,7 +159,7 @@ class PTQuery:
                 "metadata": dumps(
                     {
                         "patientId": patient_id,
-                        "refGenome": "GRCh37",
+                        "refGenome": "GRCh38",
                         "fileName": filename,
                         "updateAnnotations": "true",
                     }
@@ -345,7 +345,7 @@ class PTQuery:
             "data": dumps(
                 {
                     "gene": {"geneName": gene_name, "ensemblID": ensembl_id},
-                    "variant": {"maxFrequency": 0.05, "assemblyId": "GRCh37"},
+                    "variant": {"maxFrequency": 0.05, "assemblyId": "GRCh38"},
                 }
             ),
             "headers": {

--- a/wrappers/samtools/fastq/wrapper.py
+++ b/wrappers/samtools/fastq/wrapper.py
@@ -65,6 +65,7 @@ elif input_type == ["cram"]:
     reheader_cmd = " samtools reheader -i fastq/{family}_{sample}_header.sam {dest}; "
 
     fastq_cmd = (
+        "export REF_CACHE={snakemake.params.ref_cache}; export REF_PATH={snakemake.params.ref_cache}; "
         " samtools sort -n -T {snakemake.params.outdir}/{snakemake.wildcards.sample} {dest} | samtools fastq - --reference {snakemake.params.new_cram_ref} "
         " -1 fastq/{family}_{sample}_R1.fastq.gz"
         " -2 fastq/{family}_{sample}_R2.fastq.gz"


### PR DESCRIPTION
Minor bug fixes to enable the hg38 branch of the pipeline to run in "wes" mode.

Marked as a draft until a final top-to-bottom pipeline run with all proposed changes is completed. More details on the changes will be provided at that point.